### PR TITLE
KYLIN-1504 Use NavigableSet to store rowkey and use prefix filter to check resource path prefix instead String comparison on tomcat side

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/persistence/FileResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/FileResourceStore.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -49,12 +51,12 @@ public class FileResourceStore extends ResourceStore {
     }
 
     @Override
-    protected ArrayList<String> listResourcesImpl(String resPath) throws IOException {
+    protected NavigableSet<String> listResourcesImpl(String resPath) throws IOException {
         String[] names = file(resPath).list();
         if (names == null) // not a directory
             return null;
 
-        ArrayList<String> r = new ArrayList<String>(names.length);
+        TreeSet<String> r = new TreeSet<>();
         String prefix = resPath.endsWith("/") ? resPath : resPath + "/";
         for (String n : names) {
             r.add(prefix + n);
@@ -75,7 +77,7 @@ public class FileResourceStore extends ResourceStore {
         try {
             String commonPrefix = StringUtils.getCommonPrefix(rangeEnd, rangeStart);
             commonPrefix = commonPrefix.substring(0, commonPrefix.lastIndexOf("/") + 1);
-            final ArrayList<String> resources = listResourcesImpl(commonPrefix);
+            final NavigableSet<String> resources = listResourcesImpl(commonPrefix);
             for (String resource : resources) {
                 if (resource.compareTo(rangeStart) >= 0 && resource.compareTo(rangeEnd) <= 0) {
                     if (existsImpl(resource)) {

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceStore.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.IOUtils;
@@ -116,12 +117,12 @@ abstract public class ResourceStore {
      * return a list of child resources & folders under given path, return null
      * if given path is not a folder
      */
-    final public ArrayList<String> listResources(String resPath) throws IOException {
+    final public NavigableSet<String> listResources(String resPath) throws IOException {
         resPath = norm(resPath);
         return listResourcesImpl(resPath);
     }
 
-    abstract protected ArrayList<String> listResourcesImpl(String resPath) throws IOException;
+    abstract protected NavigableSet<String> listResourcesImpl(String resPath) throws IOException;
 
     /**
      * return true if a resource exists, return false in case of folder or
@@ -278,7 +279,7 @@ abstract public class ResourceStore {
     }
 
     public void scanRecursively(String path, Visitor visitor) throws IOException {
-        ArrayList<String> children = listResources(path);
+        NavigableSet<String> children = listResources(path);
         if (children != null) {
             for (String child : children)
                 scanRecursively(child, visitor);

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceTool.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceTool.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableSet;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.kylin.common.KylinConfig;
@@ -99,7 +100,7 @@ public class ResourceTool {
 
     public static void list(KylinConfig config, String path) throws IOException {
         ResourceStore store = ResourceStore.getStore(config);
-        ArrayList<String> result = store.listResources(path);
+        NavigableSet<String> result = store.listResources(path);
         System.out.println("" + result);
     }
 
@@ -119,7 +120,7 @@ public class ResourceTool {
     }
 
     public static void copyR(ResourceStore src, ResourceStore dst, String path) throws IOException {
-        ArrayList<String> children = src.listResources(path);
+        NavigableSet<String> children = src.listResources(path);
 
         // case of resource (not a folder)
         if (children == null) {
@@ -164,7 +165,7 @@ public class ResourceTool {
     }
 
     private static void resetR(ResourceStore store, String path) throws IOException {
-        ArrayList<String> children = store.listResources(path);
+        NavigableSet<String> children = store.listResources(path);
         if (children == null) { // path is a resource (not a folder)
             if (matchFilter(path)) {
                 store.deleteResource(path);

--- a/core-common/src/test/java/org/apache/kylin/common/persistence/LocalFileResourceStoreTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/persistence/LocalFileResourceStoreTest.java
@@ -27,6 +27,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.NavigableSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.kylin.common.KylinConfig;
@@ -91,7 +92,7 @@ public class LocalFileResourceStoreTest extends LocalFileMetadataTestCase {
         }
 
         // list
-        ArrayList<String> list;
+        NavigableSet<String> list;
 
         list = store.listResources(dir1);
         assertTrue(list.contains(path1));

--- a/core-cube/src/test/java/org/apache/kylin/cube/CubeManagerTest.java
+++ b/core-cube/src/test/java/org/apache/kylin/cube/CubeManagerTest.java
@@ -18,17 +18,6 @@
 
 package org.apache.kylin.cube;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.TimeZone;
-
-import com.google.common.collect.Lists;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.persistence.ResourceStore;
 import org.apache.kylin.common.util.JsonUtil;
@@ -40,6 +29,11 @@ import org.apache.kylin.metadata.project.ProjectManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
+import java.util.NavigableSet;
+
+import static org.junit.Assert.*;
 
 /**
  * @author yangli9
@@ -130,12 +124,12 @@ public class CubeManagerTest extends LocalFileMetadataTestCase {
     @Test
     public void testGetAllCubes() throws Exception {
         final ResourceStore store = ResourceStore.getStore(getTestConfig());
-        final ArrayList<String> cubePath = store.listResources(ResourceStore.CUBE_RESOURCE_ROOT);
+        final NavigableSet<String> cubePath = store.listResources(ResourceStore.CUBE_RESOURCE_ROOT);
         assertTrue(cubePath.size() > 1);
-        Collections.sort(cubePath);
-        final List<CubeInstance> cubes = store.getAllResources(cubePath.get(0), cubePath.get(cubePath.size() - 1), CubeInstance.class, CubeManager.CUBE_SERIALIZER);
+//        Collections.sort(cubePath);
+        final List<CubeInstance> cubes = store.getAllResources(cubePath.first(), cubePath.last(), CubeInstance.class, CubeManager.CUBE_SERIALIZER);
         assertEquals(cubePath.size(), cubes.size());
-        assertEquals(cubePath.size() - 1, store.getAllResources(cubePath.get(1), cubePath.get(cubePath.size() - 1), CubeInstance.class, CubeManager.CUBE_SERIALIZER).size());
+        assertEquals(cubePath.size() - 1, store.getAllResources(cubePath.first(), cubePath.last(), CubeInstance.class, CubeManager.CUBE_SERIALIZER).size());
     }
 
     @Test

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/DictionaryManager.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/DictionaryManager.java
@@ -18,17 +18,8 @@
 
 package org.apache.kylin.dict;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.cache.*;
+import com.google.common.collect.Lists;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.persistence.ResourceStore;
 import org.apache.kylin.dimension.Dictionary;
@@ -43,12 +34,15 @@ import org.apache.kylin.source.SourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
-import com.google.common.collect.Lists;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class DictionaryManager {
 
@@ -173,7 +167,7 @@ public class DictionaryManager {
 
     private String checkDupByContent(DictionaryInfo dictInfo, Dictionary<?> dict) throws IOException {
         ResourceStore store = MetadataManager.getInstance(config).getStore();
-        ArrayList<String> existings = store.listResources(dictInfo.getResourceDir());
+        NavigableSet<String> existings = store.listResources(dictInfo.getResourceDir());
         if (existings == null)
             return null;
 
@@ -316,13 +310,13 @@ public class DictionaryManager {
 
     private String checkDupByInfo(DictionaryInfo dictInfo) throws IOException {
         ResourceStore store = MetadataManager.getInstance(config).getStore();
-        ArrayList<String> existings = store.listResources(dictInfo.getResourceDir());
+        NavigableSet<String> existings = store.listResources(dictInfo.getResourceDir());
         if (existings == null || existings.isEmpty()) {
             return null;
         }
-        Collections.sort(existings);
+//        Collections.sort(existings);
 
-        final List<DictionaryInfo> allResources = MetadataManager.getInstance(config).getStore().getAllResources(existings.get(0), existings.get(existings.size() - 1), DictionaryInfo.class, DictionaryInfoSerializer.INFO_SERIALIZER);
+        final List<DictionaryInfo> allResources = MetadataManager.getInstance(config).getStore().getAllResources(existings.first(), existings.last(), DictionaryInfo.class, DictionaryInfoSerializer.INFO_SERIALIZER);
 
         TableSignature input = dictInfo.getInput();
 
@@ -336,13 +330,13 @@ public class DictionaryManager {
 
     private DictionaryInfo findLargestDictInfo(DictionaryInfo dictInfo) throws IOException {
         ResourceStore store = MetadataManager.getInstance(config).getStore();
-        ArrayList<String> dictInfos = store.listResources(dictInfo.getResourceDir());
+        NavigableSet<String> dictInfos = store.listResources(dictInfo.getResourceDir());
         if (dictInfos == null || dictInfos.isEmpty()) {
             return null;
         }
-        Collections.sort(dictInfos);
+//        Collections.sort(dictInfos);
 
-        final List<DictionaryInfo> allResources = MetadataManager.getInstance(config).getStore().getAllResources(dictInfos.get(0), dictInfos.get(dictInfos.size() - 1), DictionaryInfo.class, DictionaryInfoSerializer.INFO_SERIALIZER);
+        final List<DictionaryInfo> allResources = MetadataManager.getInstance(config).getStore().getAllResources(dictInfos.first(), dictInfos.last(), DictionaryInfo.class, DictionaryInfoSerializer.INFO_SERIALIZER);
 
         DictionaryInfo largestDict = null;
         for (DictionaryInfo dictionaryInfo : allResources) {
@@ -371,7 +365,7 @@ public class DictionaryManager {
         info.setSourceColumn(srcCol);
 
         ResourceStore store = MetadataManager.getInstance(config).getStore();
-        ArrayList<String> existings = store.listResources(info.getResourceDir());
+        NavigableSet<String> existings = store.listResources(info.getResourceDir());
         if (existings == null)
             return;
 

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/lookup/SnapshotManager.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/lookup/SnapshotManager.java
@@ -20,6 +20,7 @@ package org.apache.kylin.dict.lookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.NavigableSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kylin.common.KylinConfig;
@@ -137,7 +138,7 @@ public class SnapshotManager {
     private String checkDupByInfo(SnapshotTable snapshot) throws IOException {
         ResourceStore store = MetadataManager.getInstance(this.config).getStore();
         String resourceDir = snapshot.getResourceDir();
-        ArrayList<String> existings = store.listResources(resourceDir);
+        NavigableSet<String> existings = store.listResources(resourceDir);
         if (existings == null)
             return null;
 
@@ -155,7 +156,7 @@ public class SnapshotManager {
     private String checkDupByContent(SnapshotTable snapshot) throws IOException {
         ResourceStore store = MetadataManager.getInstance(this.config).getStore();
         String resourceDir = snapshot.getResourceDir();
-        ArrayList<String> existings = store.listResources(resourceDir);
+        NavigableSet<String> existings = store.listResources(resourceDir);
         if (existings == null)
             return null;
 

--- a/core-job/src/main/java/org/apache/kylin/job/dao/ExecutableDao.java
+++ b/core-job/src/main/java/org/apache/kylin/job/dao/ExecutableDao.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kylin.common.KylinConfig;
@@ -94,13 +95,13 @@ public class ExecutableDao {
 
     public List<ExecutableOutputPO> getJobOutputs() throws PersistentException {
         try {
-            ArrayList<String> resources = store.listResources(ResourceStore.EXECUTE_OUTPUT_RESOURCE_ROOT);
+            NavigableSet<String> resources = store.listResources(ResourceStore.EXECUTE_OUTPUT_RESOURCE_ROOT);
             if (resources == null || resources.isEmpty()) {
                 return Collections.emptyList();
             }
-            Collections.sort(resources);
-            String rangeStart = resources.get(0);
-            String rangeEnd = resources.get(resources.size() - 1);
+//            Collections.sort(resources);
+            String rangeStart = resources.first();
+            String rangeEnd = resources.last();
             return store.getAllResources(rangeStart, rangeEnd, ExecutableOutputPO.class, JOB_OUTPUT_SERIALIZER);
         } catch (IOException e) {
             logger.error("error get all Jobs:", e);
@@ -110,13 +111,13 @@ public class ExecutableDao {
 
     public List<ExecutableOutputPO> getJobOutputs(long timeStartInMillis, long timeEndInMillis) throws PersistentException {
         try {
-            ArrayList<String> resources = store.listResources(ResourceStore.EXECUTE_OUTPUT_RESOURCE_ROOT);
+            NavigableSet<String> resources = store.listResources(ResourceStore.EXECUTE_OUTPUT_RESOURCE_ROOT);
             if (resources == null || resources.isEmpty()) {
                 return Collections.emptyList();
             }
-            Collections.sort(resources);
-            String rangeStart = resources.get(0);
-            String rangeEnd = resources.get(resources.size() - 1);
+            // Collections.sort(resources);
+            String rangeStart = resources.first();
+            String rangeEnd = resources.last();
             return store.getAllResources(rangeStart, rangeEnd, timeStartInMillis, timeEndInMillis, ExecutableOutputPO.class, JOB_OUTPUT_SERIALIZER);
         } catch (IOException e) {
             logger.error("error get all Jobs:", e);
@@ -126,13 +127,13 @@ public class ExecutableDao {
 
     public List<ExecutablePO> getJobs() throws PersistentException {
         try {
-            final List<String> jobIds = store.listResources(ResourceStore.EXECUTE_RESOURCE_ROOT);
+            final NavigableSet<String> jobIds = store.listResources(ResourceStore.EXECUTE_RESOURCE_ROOT);
             if (jobIds == null || jobIds.isEmpty()) {
                 return Collections.emptyList();
             }
-            Collections.sort(jobIds);
-            String rangeStart = jobIds.get(0);
-            String rangeEnd = jobIds.get(jobIds.size() - 1);
+//            Collections.sort(jobIds);
+            String rangeStart = jobIds.first();
+            String rangeEnd = jobIds.last();
             return store.getAllResources(rangeStart, rangeEnd, ExecutablePO.class, JOB_SERIALIZER);
         } catch (IOException e) {
             logger.error("error get all Jobs:", e);
@@ -142,13 +143,13 @@ public class ExecutableDao {
 
     public List<ExecutablePO> getJobs(long timeStartInMillis, long timeEndInMillis) throws PersistentException {
         try {
-            final List<String> jobIds = store.listResources(ResourceStore.EXECUTE_RESOURCE_ROOT);
+            final NavigableSet<String> jobIds = store.listResources(ResourceStore.EXECUTE_RESOURCE_ROOT);
             if (jobIds == null || jobIds.isEmpty()) {
                 return Collections.emptyList();
             }
-            Collections.sort(jobIds);
-            String rangeStart = jobIds.get(0);
-            String rangeEnd = jobIds.get(jobIds.size() - 1);
+//            Collections.sort(jobIds);
+            String rangeStart = jobIds.first();
+            String rangeEnd = jobIds.last();
             return store.getAllResources(rangeStart, rangeEnd, timeStartInMillis, timeEndInMillis, ExecutablePO.class, JOB_SERIALIZER);
         } catch (IOException e) {
             logger.error("error get all Jobs:", e);
@@ -158,7 +159,7 @@ public class ExecutableDao {
 
     public List<String> getJobIds() throws PersistentException {
         try {
-            ArrayList<String> resources = store.listResources(ResourceStore.EXECUTE_RESOURCE_ROOT);
+            NavigableSet<String> resources = store.listResources(ResourceStore.EXECUTE_RESOURCE_ROOT);
             if (resources == null) {
                 return Collections.emptyList();
             }

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/steps/MetadataCleanupJob.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/steps/MetadataCleanupJob.java
@@ -18,10 +18,7 @@
 
 package org.apache.kylin.engine.mr.steps;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
@@ -114,11 +111,11 @@ public class MetadataCleanupJob extends AbstractHadoopJob {
 
         // two level resources, snapshot tables and cube statistics
         for (String resourceRoot : new String[] { ResourceStore.SNAPSHOT_RESOURCE_ROOT, ResourceStore.CUBE_STATISTICS_ROOT }) {
-            ArrayList<String> snapshotTables = getStore().listResources(resourceRoot);
+            NavigableSet<String> snapshotTables = getStore().listResources(resourceRoot);
 
             if (snapshotTables != null) {
                 for (String snapshotTable : snapshotTables) {
-                    ArrayList<String> snapshotNames = getStore().listResources(snapshotTable);
+                    NavigableSet<String> snapshotNames = getStore().listResources(snapshotTable);
                     if (snapshotNames != null)
                         for (String snapshot : snapshotNames) {
                             if (!activeResourceList.contains(snapshot)) {
@@ -131,13 +128,13 @@ public class MetadataCleanupJob extends AbstractHadoopJob {
         }
 
         // three level resources, only dictionaries
-        ArrayList<String> dictTables = getStore().listResources(ResourceStore.DICT_RESOURCE_ROOT);
+        NavigableSet<String> dictTables = getStore().listResources(ResourceStore.DICT_RESOURCE_ROOT);
 
         for (String table : dictTables) {
-            ArrayList<String> tableColNames = getStore().listResources(table);
+            NavigableSet<String> tableColNames = getStore().listResources(table);
             if (tableColNames != null)
                 for (String tableCol : tableColNames) {
-                    ArrayList<String> dictionaries = getStore().listResources(tableCol);
+                    NavigableSet<String> dictionaries = getStore().listResources(tableCol);
                     if (dictionaries != null)
                         for (String dict : dictionaries)
                             if (!activeResourceList.contains(dict)) {

--- a/kylin-it/src/test/java/org/apache/kylin/storage/hbase/ITHBaseResourceStoreTest.java
+++ b/kylin-it/src/test/java/org/apache/kylin/storage/hbase/ITHBaseResourceStoreTest.java
@@ -27,6 +27,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.NavigableSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -133,7 +134,7 @@ public class ITHBaseResourceStoreTest extends HBaseMetadataTestCase {
         }
 
         // list
-        ArrayList<String> list;
+        NavigableSet<String> list;
 
         list = store.listResources(dir1);
         assertTrue(list.contains(path1));

--- a/server/src/main/java/org/apache/kylin/rest/service/JobService.java
+++ b/server/src/main/java/org/apache/kylin/rest/service/JobService.java
@@ -90,6 +90,7 @@ public class JobService extends BasicService {
         return jobs.subList(offset, offset + limit);
     }
 
+
     public List<JobInstance> listAllJobs(final String cubeName, final String projectName, final List<JobStatusEnum> statusList, final JobTimeFilterEnum timeFilter) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(new Date());

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/HBaseResourceStore.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/HBaseResourceStore.java
@@ -22,11 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -41,10 +37,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.filter.CompareFilter;
-import org.apache.hadoop.hbase.filter.FilterList;
-import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
-import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+import org.apache.hadoop.hbase.filter.*;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.persistence.RawResource;
 import org.apache.kylin.common.persistence.ResourceStore;
@@ -117,14 +110,14 @@ public class HBaseResourceStore extends ResourceStore {
     }
 
     @Override
-    protected ArrayList<String> listResourcesImpl(String resPath) throws IOException {
+    protected NavigableSet<String> listResourcesImpl(String resPath) throws IOException {
         assert resPath.startsWith("/");
         String lookForPrefix = resPath.endsWith("/") ? resPath : resPath + "/";
         byte[] startRow = Bytes.toBytes(lookForPrefix);
         byte[] endRow = Bytes.toBytes(lookForPrefix);
         endRow[endRow.length - 1]++;
 
-        ArrayList<String> result = new ArrayList<String>();
+        TreeSet<String> result = new TreeSet<>();
 
         HTableInterface table = getConnection().getTable(getAllInOneTableName());
         Scan scan = new Scan(startRow, endRow);
@@ -136,8 +129,8 @@ public class HBaseResourceStore extends ResourceStore {
                 assert path.startsWith(lookForPrefix);
                 int cut = path.indexOf('/', lookForPrefix.length());
                 String child = cut < 0 ? path : path.substring(0, cut);
-                if (result.contains(child) == false)
-                    result.add(child);
+//                if (!result.contains(child))
+                result.add(child);
             }
         } finally {
             IOUtils.closeQuietly(table);

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/HBaseResourceStore.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/HBaseResourceStore.java
@@ -113,6 +113,7 @@ public class HBaseResourceStore extends ResourceStore {
     protected NavigableSet<String> listResourcesImpl(String resPath) throws IOException {
         assert resPath.startsWith("/");
         String lookForPrefix = resPath.endsWith("/") ? resPath : resPath + "/";
+        byte[] prefix = Bytes.toBytes(lookForPrefix);
         byte[] startRow = Bytes.toBytes(lookForPrefix);
         byte[] endRow = Bytes.toBytes(lookForPrefix);
         endRow[endRow.length - 1]++;
@@ -121,15 +122,14 @@ public class HBaseResourceStore extends ResourceStore {
 
         HTableInterface table = getConnection().getTable(getAllInOneTableName());
         Scan scan = new Scan(startRow, endRow);
-        scan.setFilter(new KeyOnlyFilter());
+        scan.setFilter(new PrefixFilter(prefix));
         try {
             ResultScanner scanner = table.getScanner(scan);
             for (Result r : scanner) {
                 String path = Bytes.toString(r.getRow());
-                assert path.startsWith(lookForPrefix);
+                // assert path.startsWith(lookForPrefix);
                 int cut = path.indexOf('/', lookForPrefix.length());
                 String child = cut < 0 ? path : path.substring(0, cut);
-//                if (!result.contains(child))
                 result.add(child);
             }
         } finally {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KYLIN-1504

- Use NavigableSet<String> instead ArrayList<String> to store natively ordered and unique row-key instead of ugly repeatedly using `Collections.sort` or check whether existing on business logic layer, in fact because the raw-key is originally sorted in hbase, the change won't consume any more computational complexity.
- Verify prefix in hbase region level using prefix filter instead of comparing String in client side.
