### PR TITLE
(KYLIN-2288) Kylin treat empty string as error measure which is inconsistent with hive

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/measure/basic/BigDecimalIngester.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/basic/BigDecimalIngester.java
@@ -33,7 +33,7 @@ public class BigDecimalIngester extends MeasureIngester<BigDecimal> {
         if (values.length > 1)
             throw new IllegalArgumentException();
 
-        if (values[0] == null)
+        if (values[0] == null || values[0].length() == 0)
             return new BigDecimal(0);
         else
             return new BigDecimal(values[0]);

--- a/core-metadata/src/main/java/org/apache/kylin/measure/basic/DoubleIngester.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/basic/DoubleIngester.java
@@ -37,7 +37,7 @@ public class DoubleIngester extends MeasureIngester<DoubleMutable> {
             throw new IllegalArgumentException();
 
         DoubleMutable l = current;
-        if (values[0] == null)
+        if (values[0] == null || values[0].length() == 0)
             l.set(0L);
         else
             l.set(Double.parseDouble(values[0]));

--- a/core-metadata/src/main/java/org/apache/kylin/measure/basic/LongIngester.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/basic/LongIngester.java
@@ -37,7 +37,7 @@ public class LongIngester extends MeasureIngester<LongMutable> {
             throw new IllegalArgumentException();
 
         LongMutable l = current;
-        if (values[0] == null)
+        if (values[0] == null || values[0].length() == 0)
             l.set(0L);
         else
             l.set(Long.parseLong(values[0]));


### PR DESCRIPTION
Assume we have a hive table
name, age 
tom, 10
jack, (empty string)
if we execute 
select count(age) from thistable;
we can get 10 as the result. (my hive version is 0.13.1)
But Kylin can not build cube for this case as BigDecimalIngester/DoubleIngester/LongIngester cannot recongnize empty string

we recognize the empty string as zero in this pr.