### PR TITLE
i think it must be a error

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/ZookeeperJobLock.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/ZookeeperJobLock.java
@@ -81,7 +81,7 @@ public class ZookeeperJobLock implements JobLock {
             logger.warn("error acquire lock", e);
         }
         if (!hasLock) {
-            logger.warn("fail to acquire lock, scheduler has not been started; maybe another kylin process is still running?");
+            logger.error("fail to acquire lock, scheduler has not been started; maybe another kylin process is still running?");
             try {
                 for (String node : sharedLock.getParticipantNodes()) {
                     logger.warn("lock holder info: {}", new String(zkClient.getData().forPath(node)));


### PR DESCRIPTION
下面是kylin.out在没有获取锁的时候输出的错误,但是,很多人应该不知道如果这里出错了,接下来会出现什么!因为其他东西看上去一切正常!
in thread "Thread-13" java.lang.RuntimeException: java.lang.IllegalStateException: Cannot start job scheduler due to lack of job lock
        at org.apache.kylin.rest.controller.JobController$1.run(JobController.java:94)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: Cannot start job scheduler due to lack of job lock
        at org.apache.kylin.job.impl.threadpool.DefaultScheduler.init(DefaultScheduler.java:203)
        at org.apache.kylin.rest.controller.JobController$1.run(JobController.java:89)
        ... 1 more


当我以为我已经成功启动后,运行官方的cube build的时候,发现第三步错误,FactDistinctColumnsJob 98行报错 IllegalStateException ,这个异常完全没有任何message(job controller挂了),脑洞想破也不知道为啥会报错, 找日志,完全没有日志(jobcontroller已经死了..),只有98行一个IllegalStateException , 想了半天看out,才知道jobcontroller 在初始化的时候就失败,压根就没启动起来,然后源码才发现ZK有锁..锁...为什么那么严重的错误 要用warn,我觉得这个warn非常有必要变成error而且出现在log里,至于为啥我zk为啥有锁,因为之前同事可能装过其他版本的,但是这种情况在一些情况下还是会发生,所以我觉得这个错误有必要暴露出来!