### PR TITLE
Fix for KYLIN-2668

### DIFF
--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnection.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnection.java
@@ -51,7 +51,7 @@ public class KylinConnection extends AvaticaConnection {
         super(driver, factory, url, info);
 
         String odbcUrl = url;
-        odbcUrl = odbcUrl.replace(Driver.CONNECT_STRING_PREFIX + "//", "");
+        odbcUrl = odbcUrl.replaceAll((Driver.CONNECT_STRING_PREFIX + "[[A-Za-z0-9]*=[A-Za-z0-9]*;]*//").toString(), "");
         String[] temps = odbcUrl.split("/");
 
         assert temps.length == 2;

--- a/jdbc/src/test/java/org/apache/kylin/jdbc/DriverTest.java
+++ b/jdbc/src/test/java/org/apache/kylin/jdbc/DriverTest.java
@@ -189,6 +189,14 @@ public class DriverTest {
         conn.close();
     }
 
+     @Test
+    public void testSSLFromURL() throws SQLException{
+        Driver driver = new DummyDriver();
+        Connection conn = driver.connect("jdbc:kylin:ssl=True;//test_url/test_db", null);
+        assertEquals("test_url", ((KylinConnection)conn).getBaseUrl());
+        assertEquals("test_db", ((KylinConnection)conn).getProject());
+    }        
+
     private void printResultSet(ResultSet rs) throws SQLException {
         ResultSetMetaData meta = rs.getMetaData();
         System.out.println("Data:");


### PR DESCRIPTION
Added the unit test and url prefix code to allow jdbc:kylin:ssl=True to be used in URL, not just java properties