### PR TITLE
fix DefaultClient may not release connection when sync wipe cache

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/restclient/RestClient.java
+++ b/core-common/src/main/java/org/apache/kylin/common/restclient/RestClient.java
@@ -121,16 +121,19 @@ public class RestClient {
         String url = baseUrl + "/cache/" + entity + "/" + cacheKey + "/" + event;
         HttpPut request = new HttpPut(url);
 
+        HttpResponse response =null;
         try {
-            HttpResponse response = client.execute(request);
+            response = client.execute(request);
+            String msg = EntityUtils.toString(response.getEntity());
 
-            if (response.getStatusLine().getStatusCode() != 200) {
-                String msg = EntityUtils.toString(response.getEntity());
+            if (response.getStatusLine().getStatusCode() != 200)
                 throw new IOException("Invalid response " + response.getStatusLine().getStatusCode() + " with cache wipe url " + url + "\n" + msg);
-            }
         } catch (Exception ex) {
             throw new IOException(ex);
         } finally {
+            if(response!=null) {
+                EntityUtils.consume(response.getEntity());
+            }
             request.releaseConnection();
         }
     }


### PR DESCRIPTION
### fix DefaultClient may not release connection when sync wipe cache

here  is error log which I added to find why sync ofthen fail

```
Thread failed during wipe cache at java.lang.IllegalStateException: Invalid use of BasicClientConnManager: connection still allocated.

```
so I add some code to make sure connection to be released


 