### PR TITLE
add retry strategy in cache sync

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -253,6 +253,10 @@ abstract public class KylinConfigBase implements Serializable {
         return StorageURL.valueOf(getOptional("kylin.metadata.url", "kylin_metadata@hbase"));
     }
 
+    public int getCacheSyncRetrys() {
+        return Integer.parseInt(getOptional("kylin.metadata.sync.retries", "3"));
+    }
+
     // for test only
     public void setMetadataUrl(String metadataUrl) {
         setProperty("kylin.metadata.url", metadataUrl);
@@ -342,7 +346,7 @@ abstract public class KylinConfigBase implements Serializable {
     public String getSegmentAdvisor() {
         return getOptional("kylin.cube.segment-advisor", "org.apache.kylin.cube.CubeSegmentAdvisor");
     }
-    
+
     public double getJobCuboidSizeRatio() {
         return Double.parseDouble(getOptional("kylin.cube.size-estimate-ratio", "0.25"));
     }

--- a/core-common/src/main/resources/kylin-defaults.properties
+++ b/core-common/src/main/resources/kylin-defaults.properties
@@ -20,6 +20,9 @@
 # The metadata store in hbase
 kylin.metadata.url=kylin_metadata@hbase
 
+# metadata cache sync retry times
+kylin.metadata.sync.retries=3
+
 # Working folder in HDFS, better be qualified absolute path, make sure user has the right permission to this directory
 kylin.env.hdfs-working-dir=/kylin
 

--- a/core-metadata/src/main/java/org/apache/kylin/metadata/cachesync/Broadcaster.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/cachesync/Broadcaster.java
@@ -111,6 +111,7 @@ public class Broadcaster {
 
     private Broadcaster(final KylinConfig config) {
         this.config = config;
+        final int retryLimitTimes = config.getCacheSyncRetrys();
 
         final String[] nodes = config.getRestServers();
         if (nodes == null || nodes.length < 1) {
@@ -128,6 +129,12 @@ public class Broadcaster {
                 while (true) {
                     try {
                         final BroadcastEvent broadcastEvent = broadcastEvents.takeFirst();
+                        broadcastEvent.setRetryTime(broadcastEvent.getRetryTime() + 1);
+                        if (broadcastEvent.getRetryTime() > retryLimitTimes) {
+                            logger.info("broadcastEvent retry up to limit times, broadcastEvent:{}", broadcastEvent);
+                            continue;
+                        }
+
                         String[] restServers = config.getRestServers();
                         logger.debug("Servers in the cluster: " + Arrays.toString(restServers));
                         for (final String node : restServers) {
@@ -145,7 +152,16 @@ public class Broadcaster {
                                         restClientMap.get(node).wipeCache(broadcastEvent.getEntity(),
                                                 broadcastEvent.getEvent(), broadcastEvent.getCacheKey());
                                     } catch (IOException e) {
-                                        logger.warn("Thread failed during wipe cache at " + broadcastEvent, e);
+                                        logger.warn("Thread failed during wipe cache at {}, error msg: {}",
+                                                broadcastEvent, e);
+                                        // when sync failed, put back to queue
+                                        try {
+                                            broadcastEvents.putLast(broadcastEvent);
+                                        } catch (InterruptedException ex) {
+                                            logger.warn(
+                                                    "error reentry failed broadcastEvent to queue, broacastEvent:{}, error: {} ",
+                                                    broadcastEvent, ex);
+                                        }
                                     }
                                 }
                             });
@@ -297,6 +313,7 @@ public class Broadcaster {
     }
 
     public static class BroadcastEvent {
+        private int retryTime;
         private String entity;
         private String event;
         private String cacheKey;
@@ -306,6 +323,14 @@ public class Broadcaster {
             this.entity = entity;
             this.event = event;
             this.cacheKey = cacheKey;
+        }
+
+        public int getRetryTime() {
+            return retryTime;
+        }
+
+        public void setRetryTime(int retryTime) {
+            this.retryTime = retryTime;
         }
 
         public String getEntity() {

--- a/server/src/test/java/org/apache/kylin/rest/service/CacheServiceTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/service/CacheServiceTest.java
@@ -155,6 +155,10 @@ public class CacheServiceTest extends LocalFileMetadataTestCase {
     private void waitForCounterAndClear(long count) {
         int retryTimes = 0;
         while ((!counter.compareAndSet(count, 0L))) {
+            // take into account wipe retry causing counter larger than count
+            if (counter.get() > count) {
+                counter.decrementAndGet();
+            }
             if (++retryTimes > 30) {
                 throw new RuntimeException("timeout");
             }


### PR DESCRIPTION
since there may be an situation that when sync request call a node that is down temporary and is restarting, sync cache may fail.  So I add a retry strategy to avoid that situation 

