### PR TITLE
satisfy multi-path of domain for kylin connection (against master)

### DIFF
--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnection.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnection.java
@@ -52,12 +52,12 @@ public class KylinConnection extends AvaticaConnection {
 
         String odbcUrl = url;
         odbcUrl = odbcUrl.replaceAll((Driver.CONNECT_STRING_PREFIX + "[[A-Za-z0-9]*=[A-Za-z0-9]*;]*//").toString(), "");
-        
-        String[] temps = odbcUrl.split("/");
-        assert temps.length == 2;
 
-        this.baseUrl = temps[0];
-        this.project = temps[1];
+        String[] temps = odbcUrl.split("/");
+        assert temps.length >= 2;
+
+        this.project = temps[temps.length - 1];
+        this.baseUrl = odbcUrl.substring(0, odbcUrl.indexOf(project) - 1);
 
         logger.debug("Kylin base url " + this.baseUrl + ", project name " + this.project);
 

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnection.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnection.java
@@ -57,7 +57,7 @@ public class KylinConnection extends AvaticaConnection {
         assert temps.length >= 2;
 
         this.project = temps[temps.length - 1];
-        this.baseUrl = odbcUrl.substring(0, odbcUrl.indexOf(project) - 1);
+        this.baseUrl = odbcUrl.substring(0, odbcUrl.lastIndexOf(project) - 1);
 
         logger.debug("Kylin base url " + this.baseUrl + ", project name " + this.project);
 

--- a/jdbc/src/test/java/org/apache/kylin/jdbc/DriverTest.java
+++ b/jdbc/src/test/java/org/apache/kylin/jdbc/DriverTest.java
@@ -105,6 +105,29 @@ public class DriverTest {
     }
 
     @Test
+    public void testMultipathOfDomainForConnection() throws SQLException {
+        Driver driver = new DummyDriver();
+
+        Connection conn = driver.connect("jdbc:kylin://test_url/kylin/test_db/", null);
+        Statement state = conn.createStatement();
+        ResultSet resultSet = state.executeQuery("select * from test_table where url not in ('http://a.b.com/?a=b') limit 1");
+        ResultSetMetaData metadata = resultSet.getMetaData();
+        assertEquals(12, metadata.getColumnType(1));
+        assertEquals("varchar", metadata.getColumnTypeName(1));
+        assertEquals(1, metadata.isNullable(1));
+
+        while (resultSet.next()) {
+            assertEquals("foo", resultSet.getString(1));
+            assertEquals("bar", resultSet.getString(2));
+            assertEquals("tool", resultSet.getString(3));
+        }
+
+        resultSet.close();
+        state.close();
+        conn.close();
+    }
+
+    @Test
     public void testPreparedStatementWithMockData() throws SQLException {
         Driver driver = new DummyDriver();
 


### PR DESCRIPTION
So far, Kylin JDBC only satisfies domain/project pattern, but many companies use multi-path of domain. For example, domain/path/project. I improve this issue. @yiming187  Please review this issue.