### PR TITLE
KYLIN-3305 Fix typos `kylin.job.run.as.remote.cmd`

### DIFF
--- a/website/_dev/dev_env.md
+++ b/website/_dev/dev_env.md
@@ -87,7 +87,7 @@ Local configuration must be modified to point to your hadoop sandbox (or CLI) ma
 
 * In **examples/test_case_data/sandbox/kylin.properties**
    * Find `sandbox` and replace with your hadoop hosts (if you're using HDP sandbox, this can be skipped)
-   * Find `kylin.job.run.as.remote.cmd` and change it to "true" (in code repository the default is false, which assume running it on hadoop CLI)
+   * Find `kylin.job.use-remote-cli` and change it to "true" (in code repository the default is false, which assume running it on hadoop CLI)
    * Find `kylin.job.remote.cli.username` and `kylin.job.remote.cli.password`, fill in the user name and password used to login hadoop cluster for hadoop command execution; If you're using HDP sandbox, the default username is `root` and password is `hadoop`.
 
 * In **examples/test_case_data/sandbox**

--- a/website/_dev/howto_test.md
+++ b/website/_dev/howto_test.md
@@ -52,7 +52,7 @@ If your sandbox is already provisioned and your code change will not affect the 
 
 ### Cube Provision
 
-Environment cube provision is indeed running kylin cubing jobs to prepare example cubes in the sandbox. These prepared cubes will be used by the ITs. Currently provision step is bound with the maven pre-integration-test phase, and it contains running BuildCubeWithEngine (HBase required), BuildCubeWithStream(Kafka required) and BuildIIWithStream(Kafka Required). You can run the mvn commands on you sandbox or your develop computer. For the latter case you need to set kylin.job.run.as.remote.cmd=true in __$KYLIN_HOME/examples/test_case_data/sandbox/kylin.properties__. 
+Environment cube provision is indeed running kylin cubing jobs to prepare example cubes in the sandbox. These prepared cubes will be used by the ITs. Currently provision step is bound with the maven pre-integration-test phase, and it contains running BuildCubeWithEngine (HBase required), BuildCubeWithStream(Kafka required) and BuildIIWithStream(Kafka Required). You can run the mvn commands on you sandbox or your develop computer. For the latter case you need to set kylin.job.use-remote-cli=true in __$KYLIN_HOME/examples/test_case_data/sandbox/kylin.properties__. 
 Try appending `-DfastBuildMode=true` to mvn verify command to speed up provision by skipping incremental cubing. 
 
 ## More on v1.3 Mini Cluster


### PR DESCRIPTION
KYLIN-3305 Fix typos `kylin.job.run.as.remote.cmd`