### PR TITLE
KYLIN-3336

### DIFF
--- a/tool/src/main/java/org/apache/kylin/tool/DiagnosisInfoCLI.java
+++ b/tool/src/main/java/org/apache/kylin/tool/DiagnosisInfoCLI.java
@@ -192,7 +192,7 @@ public class DiagnosisInfoCLI extends AbstractInfoExtractor {
                                 projectNames, "-compress", "false", "-submodule", "true" };
                         logger.info("HBaseUsageExtractor args: " + Arrays.toString(hbaseArgs));
                         Object extractor = ClassUtil.newInstance("org.apache.kylin.tool.HBaseUsageExtractor");
-                        Method execute = extractor.getClass().getDeclaredMethod("execute", String[].class);
+                        Method execute = extractor.getClass().getMethod("execute", String[].class);
                         execute.invoke(extractor, (Object) hbaseArgs);
                     } catch (Throwable e) {
                         logger.error("Error in export HBase usage.", e);


### PR DESCRIPTION
When using diag.sh, got following exception:
2018-04-04 16:14:18,222 ERROR [pool-7-thread-3] tool.DiagnosisInfoCLI:171 : Error in export HBase usage.
java.lang.NoSuchMethodException: org.apache.kylin.tool.HBaseUsageExtractor.execute([Ljava.lang.String;)
        at java.lang.Class.getDeclaredMethod(Class.java:2017)
        at org.apache.kylin.tool.DiagnosisInfoCLI$3.run(DiagnosisInfoCLI.java:168)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1152)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:622)
        at java.lang.Thread.run(Thread.java:745)

Because getDeclaredMethod(String name, Class<?>... parameterTypes) can not get the inherited methods