### PR TITLE
Analytic table name ArrayIndexOutOfBoundsException

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
@@ -100,7 +100,7 @@ public class DeployCoprocessorCLI {
             if ("default".equals(args[curIdx++])) {
                 localCoprocessorJar = kylinConfig.getCoprocessorLocalJar();
             } else {
-                localCoprocessorJar = new File(args[curIdx++]).getAbsolutePath();
+                localCoprocessorJar = new File(args[curIdx]).getAbsolutePath();
             }
 
             logger.info("Identify coprocessor jar " + localCoprocessorJar);


### PR DESCRIPTION
Called without a default parameter will result in
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 2
	at org.apache.kylin.storage.hbase.util.DeployCoprocessorCLI.main(DeployCoprocessorCLI.java:118)
In 100 lines to determine if the first parameter of the command line is default, curIdx has ++, if the first parameter is not the default line 103, curIdx is re-++, resulting in the parameter misalignment.