### PR TITLE
KYLIN-3553 Tomcat Security Vulnerability Alert. The version of the tomcat for kylin should upgrade to 7.0.90.

### DIFF
--- a/build/script/download-tomcat.sh
+++ b/build/script/download-tomcat.sh
@@ -27,8 +27,8 @@ if [[ `uname -a` =~ "Darwin" ]]; then
     alias md5cmd="md5 -q"
 fi
 
-tomcat_pkg_version="7.0.85"
-tomcat_pkg_md5="1ad4760080164bb08e924c330703c94d"
+tomcat_pkg_version="7.0.90"
+tomcat_pkg_md5="cd4890e4e6a212dafd970da37d040877"
 
 if [ ! -f "build/apache-tomcat-${tomcat_pkg_version}.tar.gz" ]
 then

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <cglib.version>3.2.4</cglib.version>
     <supercsv.version>2.4.0</supercsv.version>
     <cors.version>2.5</cors.version>
-    <tomcat.version>7.0.85</tomcat.version>
+    <tomcat.version>7.0.90</tomcat.version>
     <t-digest.version>3.1</t-digest.version>
     <freemarker.version>2.3.23</freemarker.version>
     <rocksdb.version>5.9.2</rocksdb.version>


### PR DESCRIPTION
[SECURITY] CVE-2018-1336
Severity: High 
Versions Affected: Apache Tomcat 9.0.0.M9 to 9.0.7, 8.5.0 to 8.5.30, 8.0.0.RC1 to 8.0.51, and 7.0.28 to 7.0.86.
Description: An improper handing of overflow in the UTF-8 decoder with supplementary characters can lead to an infinite loop in the decoder causing a Denial of Service.

CVE-2018-8014
Description: The defaults settings for the CORS filter provided in Apache Tomcat 9.0.0.M1 to 9.0.8, 8.5.0 to 8.5.31, 8.0.0.RC1 to 8.0.52, 7.0.41 to 7.0.88 are insecure and enable 'supportsCredentials' for all origins. It is expected that users of the CORS filter will have configured it appropriately for their environment rather than using it in the default configuration. Therefore, it is expected that most users will not be impacted by this issue.

CVE-2018-8034
Description: The host name verification when using TLS with the WebSocket client was missing. It is now enabled by default. 
Versions Affected: Apache Tomcat 9.0.0.M1 to 9.0.9, 8.5.0 to 8.5.31, 8.0.0.RC1 to 8.0.52, and 7.0.35 to 7.0.88.