### PR TITLE
KYLIN-3656  Improve HLLCounter performance

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/measure/hllc/DenseRegister.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/hllc/DenseRegister.java
@@ -35,6 +35,11 @@ public class DenseRegister implements Register, java.io.Serializable {
         this.register = new byte[m];
     }
 
+    public void  copyFrom(DenseRegister r){
+        assert m == r.m;
+        System.arraycopy(r.register, 0, register, 0 , register.length);
+    }
+
     public void set(int pos, byte value) {
         register[pos] = value;
     }


### PR DESCRIPTION
The current HLLCounter implementation has some room to improve performance, as we find in our product environment. Improvement related to getCountEstimate of HLLCounter and constructor of HLLCounter.


- Create HLLCounter from another HLLCounter, we can copy register(using System.arraycopy) instead of merge. (Constructor of HLLCounter)
- Precompute harmonic mean in the HLLCSnapshot to avoid doing this on the fly. (getCountEstimate of HLLCounter)

UnitTest has add cost duration compare.