### PR TITLE
KYLIN-3290 Leverage getDecalredConstructor().newInstance() instead of newInstance()

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/ClassUtil.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/ClassUtil.java
@@ -85,7 +85,7 @@ public class ClassUtil {
 
     public static Object newInstance(String clz) {
         try {
-            return forName(clz, Object.class).newInstance();
+            return forName(clz, Object.class).getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/DictionaryInfoSerializer.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/DictionaryInfoSerializer.java
@@ -21,6 +21,7 @@ package org.apache.kylin.dict;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import org.apache.kylin.common.persistence.Serializer;
 import org.apache.kylin.common.util.ClassUtil;
@@ -63,14 +64,19 @@ public class DictionaryInfoSerializer implements Serializer<DictionaryInfo> {
         if (infoOnly == false) {
             Dictionary<String> dict;
             try {
-                dict = (Dictionary<String>) ClassUtil.forName(obj.getDictionaryClass(), Dictionary.class).newInstance();
+                dict = (Dictionary<String>) ClassUtil.forName(obj.getDictionaryClass(), Dictionary.class).getDeclaredConstructor().newInstance();
             } catch (InstantiationException e) {
                 throw new RuntimeException(e);
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeException(e);
             }
+
             dict.readFields(in);
             obj.setDictionaryObject(dict);
         }

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/DictionarySerializer.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/DictionarySerializer.java
@@ -41,7 +41,7 @@ public final class DictionarySerializer {
         try {
             final DataInputStream dataInputStream = new DataInputStream(inputStream);
             final String type = dataInputStream.readUTF();
-            final Dictionary<?> dictionary = ClassUtil.forName(type, Dictionary.class).newInstance();
+            final Dictionary<?> dictionary = ClassUtil.forName(type, Dictionary.class).getDeclaredConstructor().newInstance();
             dictionary.readFields(dataInputStream);
             return dictionary;
         } catch (Exception e) {

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary.java
@@ -49,7 +49,7 @@ public class NumberDictionary<T> extends TrieDictionary<T> {
     @Override
     protected void setConverterByName(String converterName) throws Exception {
         converterName = "org.apache.kylin.dict.Number2BytesConverter";
-        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).newInstance();
+        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
         ((Number2BytesConverter)this.bytesConvert).setMaxDigitsBeforeDecimalPoint(Number2BytesConverter.MAX_DIGITS_BEFORE_DECIMAL_POINT_LEGACY);
     }
 

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary2.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary2.java
@@ -40,7 +40,7 @@ public class NumberDictionary2<T> extends NumberDictionary<T> {
     @Override
     protected void setConverterByName(String converterName) throws Exception {
         converterName = "org.apache.kylin.dict.Number2BytesConverter";
-        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).newInstance();
+        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
     }
 
 }

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/TrieDictionary.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/TrieDictionary.java
@@ -126,7 +126,7 @@ public class TrieDictionary<T> extends CacheDictionary<T> {
     }
 
     protected void setConverterByName(String converterName) throws Exception {
-        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).newInstance();
+        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
     }
 
     @Override

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/TrieDictionaryForest.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/TrieDictionaryForest.java
@@ -211,7 +211,7 @@ public class TrieDictionaryForest<T> extends CacheDictionary<T> {
             String converterName = in.readUTF();
             BytesConverter<T> bytesConverter = null;
             if (converterName.isEmpty() == false)
-                bytesConverter = ClassUtil.forName(converterName, BytesConverter.class).newInstance();
+                bytesConverter = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
             //init accuOffset
             int accuSize = in.readInt();
             ArrayList<Integer> accuOffset = new ArrayList<>();

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/global/GlobalDictHDFSStore.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/global/GlobalDictHDFSStore.java
@@ -316,7 +316,7 @@ public class GlobalDictHDFSStore extends GlobalDictStore {
                 String converterName = in.readUTF();
                 BytesConverter converter;
                 try {
-                    converter = ClassUtil.forName(converterName, BytesConverter.class).newInstance();
+                    converter = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
                 } catch (Exception e) {
                     throw new RuntimeException("Fail to instantiate BytesConverter: " + converterName, e);
                 }
@@ -386,7 +386,7 @@ public class GlobalDictHDFSStore extends GlobalDictStore {
                 String converterName = in.readUTF();
                 BytesConverter converter;
                 try {
-                    converter = ClassUtil.forName(converterName, BytesConverter.class).newInstance();
+                    converter = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
                 } catch (Exception e) {
                     throw new RuntimeException("Fail to instantiate BytesConverter: " + converterName, e);
                 }

--- a/kylin-it/src/test/java/org/apache/kylin/jdbc/ITJDBCDriverTest.java
+++ b/kylin-it/src/test/java/org/apache/kylin/jdbc/ITJDBCDriverTest.java
@@ -96,7 +96,7 @@ public class ITJDBCDriverTest extends HBaseMetadataTestCase {
 
     protected Connection getConnection() throws Exception {
 
-        Driver driver = (Driver) Class.forName("org.apache.kylin.jdbc.Driver").newInstance();
+        Driver driver = (Driver) Class.forName("org.apache.kylin.jdbc.Driver").getDeclaredConstructor().newInstance();
         Properties info = new Properties();
         info.put("user", "ADMIN");
         info.put("password", "KYLIN");

--- a/query/src/main/java/org/apache/kylin/query/QueryConnection.java
+++ b/query/src/main/java/org/apache/kylin/query/QueryConnection.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.query;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -38,9 +39,9 @@ public class QueryConnection {
             try {
                 Class<?> aClass = Thread.currentThread().getContextClassLoader()
                         .loadClass("org.apache.calcite.jdbc.Driver");
-                Driver o = (Driver) aClass.newInstance();
+                Driver o = (Driver) aClass.getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(o);
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                 e.printStackTrace();
             }
             isRegister = true;

--- a/query/src/main/java/org/apache/kylin/query/relnode/OLAPAggregateRel.java
+++ b/query/src/main/java/org/apache/kylin/query/relnode/OLAPAggregateRel.java
@@ -110,7 +110,7 @@ public class OLAPAggregateRel extends Aggregate implements OLAPRel {
         for (String func : udafs.keySet()) {
             try {
                 AGGR_FUNC_PARAM_AS_MEASURE_MAP.put(func,
-                        ((ParamAsMeasureCount) (udafs.get(func).newInstance())).getParamAsMeasureCount());
+                        ((ParamAsMeasureCount) (udafs.get(func).getDeclaredConstructor().newInstance())).getParamAsMeasureCount());
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/server-base/src/test/java/org/apache/kylin/rest/bean/BeanValidator.java
+++ b/server-base/src/test/java/org/apache/kylin/rest/bean/BeanValidator.java
@@ -67,7 +67,7 @@ public class BeanValidator {
                     try {
                         Object value = buildValue(returnType);
 
-                        T bean = clazz.newInstance();
+                        T bean = clazz.getDeclaredConstructor().newInstance();
 
                         setter.invoke(bean, value);
 


### PR DESCRIPTION
Issue : https://issues.apache.org/jira/browse/KYLIN-3290
How to fix : Leverage getDecalredConstructor().newInstance() instead of newInstance() 