### PR TITLE
minor, clean deprecated configuration "kylin.job.controller.lock" in kylin-backward-compatibility.properties

### DIFF
--- a/core-common/src/main/resources/kylin-backward-compatibility.properties
+++ b/core-common/src/main/resources/kylin-backward-compatibility.properties
@@ -62,7 +62,6 @@ kylin.job.cubing.inmem.sampling.percent=kylin.job.sampling-percentage
 kylin.job.cubing.inmem.sampling.hll.precision=kylin.job.sampling-hll-precision
 kylin.job.dependency.filterlist=kylin.job.dependency-filter-list
 kylin.job.retry=kylin.job.retry
-kylin.job.controller.lock=kylin.job.lock
 kylin.scheduler.=kylin.job.scheduler.provider.
 kylin.enable.scheduler=kylin.job.scheduler.default
 


### PR DESCRIPTION
Hi @shaofengshi , the previous commit don't clean this deprecated configuration completely. It's clean now.

![image](https://user-images.githubusercontent.com/15643702/49325012-a13e6600-f575-11e8-9f52-3cfde7ed8838.png)

![image](https://user-images.githubusercontent.com/15643702/49325014-a7ccdd80-f575-11e8-9e4e-85e2f33d0958.png)
