### PR TITLE
KYLIN-1111 Ignore unsupported hive column types when sync hive table

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/metadata/datatype/DataType.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/datatype/DataType.java
@@ -152,6 +152,17 @@ public class DataType implements Serializable {
         return cached;
     }
 
+    public static boolean isSupportedType(String typeName) {
+        if (typeName == null) {
+            return false;
+        }
+
+        String formattedTypeName = typeName.trim().toLowerCase(Locale.ROOT);
+        formattedTypeName = replaceLegacy(formattedTypeName);
+
+        return TYPE_PATTERN.matcher(formattedTypeName).matches() || COMPLEX_TYPE_PATTERN.matcher(formattedTypeName).matches();
+    }
+
     public static boolean isNumberFamily(String name) {
         return NUMBER_FAMILY.contains(name);
     }
@@ -237,7 +248,7 @@ public class DataType implements Serializable {
         return getOrder().compare(value1,  value2);
     }
 
-    private String replaceLegacy(String str) {
+    private static String replaceLegacy(String str) {
         String replace = LEGACY_TYPE_MAP.get(str);
         return replace == null ? str : replace;
     }

--- a/core-metadata/src/test/java/org/apache/kylin/metadata/datatype/DataTypeTest.java
+++ b/core-metadata/src/test/java/org/apache/kylin/metadata/datatype/DataTypeTest.java
@@ -31,4 +31,11 @@ public class DataTypeTest {
         Assert.assertTrue(DataType.isComplexType(arrayInt));
         Assert.assertTrue(DataType.isComplexType(arrayString));
     }
+
+    @Test
+    public void testIsSupportedType() {
+        Assert.assertTrue(DataType.isSupportedType("array<int>"));
+        Assert.assertFalse(DataType.isSupportedType("map<string, int>"));
+        Assert.assertFalse(DataType.isSupportedType(null));
+    }
 }

--- a/source-hive/src/main/java/org/apache/kylin/source/hive/HiveMetadataExplorer.java
+++ b/source-hive/src/main/java/org/apache/kylin/source/hive/HiveMetadataExplorer.java
@@ -31,6 +31,7 @@ import org.apache.kylin.common.util.HiveCmdBuilder;
 import org.apache.kylin.common.util.Pair;
 import org.apache.kylin.common.util.RandomUtil;
 import org.apache.kylin.metadata.TableMetadataManager;
+import org.apache.kylin.metadata.datatype.DataType;
 import org.apache.kylin.metadata.model.ColumnDesc;
 import org.apache.kylin.metadata.model.TableDesc;
 import org.apache.kylin.metadata.model.TableExtDesc;
@@ -238,21 +239,25 @@ public class HiveMetadataExplorer implements ISourceMetadataExplorer, ISampleDat
 
         for (int i = 0; i < columnNumber; i++) {
             HiveTableMeta.HiveTableColumnMeta field = hiveTableMeta.allColumns.get(i);
-            ColumnDesc cdesc = new ColumnDesc();
-            cdesc.setName(field.name.toUpperCase(Locale.ROOT));
 
-            // use "double" in kylin for "float"
-            if ("float".equalsIgnoreCase(field.dataType)) {
-                cdesc.setDatatype("double");
-            } else {
-                cdesc.setDatatype(field.dataType);
+            // skip unsupported fields, e.g. map<string, int>
+            if (DataType.isSupportedType(field.dataType)) {
+                ColumnDesc cdesc = new ColumnDesc();
+                cdesc.setName(field.name.toUpperCase(Locale.ROOT));
+
+                // use "double" in kylin for "float"
+                if ("float".equalsIgnoreCase(field.dataType)) {
+                    cdesc.setDatatype("double");
+                } else {
+                    cdesc.setDatatype(field.dataType);
+                }
+
+                cdesc.setId(String.valueOf(i + 1));
+                cdesc.setComment(field.comment);
+                columns.add(cdesc);
             }
-
-            cdesc.setId(String.valueOf(i + 1));
-            cdesc.setComment(field.comment);
-            columns.add(cdesc);
         }
 
-        return columns.toArray(new ColumnDesc[columnNumber]);
+        return  columns.toArray(new ColumnDesc[0]);
     }
 }


### PR DESCRIPTION
Issue : https://issues.apache.org/jira/browse/KYLIN-1111
Solution : Filter in HiveMetadataExplorer#extractColumnFromMeta
How to verify:
1. add new UT
2. Verified with IT:
[INFO] Apache Kylin - Integration Test .................... SUCCESS [  02:30 h]
[INFO] Apache Kylin - Tomcat Extension .................... SUCCESS [  2.303 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:47 h
[INFO] Finished at: 2018-12-05T18:29:37Z
[INFO] ------------------------------------------------------------------------
3. Manual add a Hive table with map<string, int>, and try to load into Kylin
