### PR TITLE
set JAVA_HOME before server start or stop

### DIFF
--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -30,6 +30,8 @@ fi
 mkdir -p ${KYLIN_HOME}/logs
 mkdir -p ${KYLIN_HOME}/ext
 
+source ${dir}/set-java-home.sh
+
 function retrieveDependency() {
     #retrive $hive_dependency and $hbase_dependency
     source ${dir}/find-hive-dependency.sh

--- a/build/bin/set-java-home.sh
+++ b/build/bin/set-java-home.sh
@@ -26,3 +26,10 @@ then
     fi
     export JAVA_HOME=$JAVA_HOME
 fi
+
+# Validate kylin JDK version
+JAVA_VERSION=$(hbase -version 2>&1  | awk -F '"' '/version/ {print $2}' | awk -F "." '{print $1$2}')
+if [ "$JAVA_VERSION" -lt 18 ]
+then
+    quit "Kylin requires JDK 1.8+, please install or upgrade your JDK"
+fi

--- a/build/bin/set-java-home.sh
+++ b/build/bin/set-java-home.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -z "${JAVA_HOME}" ]
+then
+    JAVA_HOME=$(readlink -nf $(which java) | xargs dirname | xargs dirname | xargs dirname)
+    if [ ! -e "$JAVA_HOME" ]  # nonexistent home
+    then
+        JAVA_HOME=""
+    fi
+    export JAVA_HOME=$JAVA_HOME
+fi


### PR DESCRIPTION
We believe that the following scenario is fairly common in big data communities:
  1. Have CDH 5.x with JDK 1.7 (/usr/lib/jvm/java-7-oracle-cloudera)
  2. Have JDK 1.8+ for other usage (e.g., kylin 2.5.2+ runs on 1.8+)

The added  set-java-home.sh will try to set JAVA_HOME before start or stop the server.

If JAVA_HOME is not set, under the above scenario, kylin server would try to start with JDK 1.7.  And many jars built after kylin 2.5.0 would NOT run on jdk 1.7.

