### PR TITLE
Kylin 3726: KylinSession should load spark properties from spark-defaults.conf

### DIFF
--- a/engine-spark/src/main/java/org/apache/spark/sql/KylinSession.scala
+++ b/engine-spark/src/main/java/org/apache/spark/sql/KylinSession.scala
@@ -30,7 +30,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession.Builder
 import org.apache.spark.sql.internal.{SessionState, SharedState}
 import org.apache.spark.sql.manager.UdfManager
-import org.apache.spark.util.{KylinReflectUtils, XmlUtils}
+import org.apache.spark.util.{KylinReflectUtils, Utils, XmlUtils}
 import org.apache.spark.{SparkConf, SparkContext}
 
 import scala.collection.JavaConverters._
@@ -133,7 +133,8 @@ object KylinSession extends Logging {
 
     def initSparkConf(): SparkConf = {
       val sparkConf = new SparkConf()
-
+      logInfo("Try to load spark properties from spark-defaults.conf")
+      Utils.loadDefaultSparkProperties(sparkConf)
       kylinConfig.getSparkConf.asScala.foreach {
         case (k, v) =>
           sparkConf.set(k, v)


### PR DESCRIPTION
When testing parquet storage, the spark session job failed to be submit for no JAVA_HOME in executor env. This config is set in the spark default property file: spark-defaults.conf.

```
2018-12-18,15:13:15,466 ERROR org.apache.spark.deploy.yarn.YarnAllocator: Failed to launch executor 6 on container container_e823_1541646991414_1025309_01_000007
java.util.NoSuchElementException: key not found: JAVA_HOME
	at scala.collection.MapLike$class.default(MapLike.scala:228)
	at scala.collection.AbstractMap.default(Map.scala:59)
	at scala.collection.mutable.HashMap.apply(HashMap.scala:65)
	at org.apache.spark.deploy.yarn.ExecutorRunnable$$anonfun$prepareEnvironment$3$$anonfun$apply$3.apply(ExecutorRunnable.scala:286)
	at org.apache.spark.deploy.yarn.ExecutorRunnable$$anonfun$prepareEnvironment$3$$anonfun$apply$3.apply(ExecutorRunnable.scala:275)
	at scala.Option.foreach(Option.scala:257)
	at org.apache.spark.deploy.yarn.ExecutorRunnable$$anonfun$prepareEnvironment$3.apply(ExecutorRunnable.scala:275)
	at org.apache.spark.deploy.yarn.ExecutorRunnable$$anonfun$prepareEnvironment$3.apply(ExecutorRunnable.scala:274)
	at scala.Option.foreach(Option.scala:257)
	at org.apache.spark.deploy.yarn.ExecutorRunnable.prepareEnvironment(ExecutorRunnable.scala:274)
	at org.apache.spark.deploy.yarn.ExecutorRunnable.startContainer(ExecutorRunnable.scala:92)
	at org.apache.spark.deploy.yarn.ExecutorRunnable.run(ExecutorRunnable.scala:69)
	at org.apache.spark.deploy.yarn.YarnAllocator$$anonfun$runAllocatedContainers$1$$anon$1.run(YarnAllocator.scala:556)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```