### PR TITLE
KYLIN-3752 Increase broadcaster's concurrency to avoid exceptions

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/metadata/cachesync/Broadcaster.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/cachesync/Broadcaster.java
@@ -91,14 +91,17 @@ public class Broadcaster {
         this.config = config;
         this.syncErrorHandler = getSyncErrorHandler(config);
         this.announceMainLoop = Executors.newSingleThreadExecutor(new DaemonThreadFactory());
-        this.announceThreadPool = new ThreadPoolExecutor(1, 10, 60L, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<Runnable>(), new DaemonThreadFactory());
-
+        
         final String[] nodes = config.getRestServers();
         if (nodes == null || nodes.length < 1) {
             logger.warn("There is no available rest server; check the 'kylin.server.cluster-servers' config");
         }
         logger.debug("{} nodes in the cluster: {}", (nodes == null ? 0 : nodes.length), Arrays.toString(nodes));
+        
+        int corePoolSize = (nodes == null || nodes.length < 1)? 1 : nodes.length;
+        int maximumPoolSize = (nodes == null || nodes.length < 1)? 10 : nodes.length * 2;
+        this.announceThreadPool = new ThreadPoolExecutor(corePoolSize, maximumPoolSize, 60L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<Runnable>(), new DaemonThreadFactory());
 
         announceMainLoop.execute(new Runnable() {
             @Override


### PR DESCRIPTION
Increase broadcast concurrency to avoid exceptions:
org.apache.kylin.job.exception.ExecuteException: org.apache.kylin.job.exception.ExecuteException: java.lang.NullPointerException
        at org.apache.kylin.job.execution.AbstractExecutable.execute(AbstractExecutable.java:178)
        at org.apache.kylin.job.impl.threadpool.DistributedScheduler$JobRunner.run(DistributedScheduler.java:111)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.kylin.job.exception.ExecuteException: java.lang.NullPointerException
        at org.apache.kylin.job.execution.AbstractExecutable.execute(AbstractExecutable.java:178)
        at org.apache.kylin.job.execution.DefaultChainedExecutable.doWork(DefaultChainedExecutable.java:69)
        at org.apache.kylin.job.execution.AbstractExecutable.execute(AbstractExecutable.java:163)
        ... 4 more
Caused by: java.lang.NullPointerException
        at org.apache.kylin.source.hive.CreateFlatHiveTableStep.getCubeSpecificConfig(CreateFlatHiveTableStep.java:92)
        at org.apache.kylin.source.hive.CreateFlatHiveTableStep.doWork(CreateFlatHiveTableStep.java:97)
        at org.apache.kylin.job.execution.AbstractExecutable.execute(AbstractExecutable.java:163)
        ... 6 more