### PR TITLE
KYLIN-3776 Float type in MySQL not properly converted to HIVE Double …

### DIFF
--- a/source-jdbc/src/main/java/org/apache/kylin/source/jdbc/SqlUtil.java
+++ b/source-jdbc/src/main/java/org/apache/kylin/source/jdbc/SqlUtil.java
@@ -159,6 +159,7 @@ public class SqlUtil {
     }
 
     public static boolean isScaleApplicable(String typeName) {
-        return DataType.NUMBER_FAMILY.contains(typeName) && !DataType.INTEGER_FAMILY.contains(typeName);
+        return !"double".equalsIgnoreCase(typeName) && !"float".equalsIgnoreCase(typeName) &&
+                DataType.NUMBER_FAMILY.contains(typeName) && !DataType.INTEGER_FAMILY.contains(typeName);
     }
 }


### PR DESCRIPTION
In Hive DDL manual, the precision/scale of double and float is not configurable