### PR TITLE
KYLIN-3494: Build cube with spark reports ArrayIndexOutOfBoundsException

### DIFF
--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkUtil.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkUtil.java
@@ -161,7 +161,7 @@ public class SparkUtil {
                     @Override
                     public String[] call(Text text) throws Exception {
                         String s = Bytes.toString(text.getBytes(), 0, text.getLength());
-                        return s.split(BatchConstants.SEQUENCE_FILE_DEFAULT_DELIMITER);
+                        return s.split(BatchConstants.SEQUENCE_FILE_DEFAULT_DELIMITER, -1);
                     }
                 });
     }


### PR DESCRIPTION
The default string split method will remove empty values.  This will lose null column fields and cause ArrayIndexOutOfBoundsException in BaseCuboidBuilder.

Just fix it using string split with -1 limit.
See: https://stackoverflow.com/questions/14602062/java-string-split-removed-empty-values