### PR TITLE
Kylin 3809: Support Zookeeper based rest server discovery

### DIFF
--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -73,7 +73,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-x-discovery</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>

--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -40,6 +40,7 @@ import org.apache.kylin.common.lock.DistributedLockFactory;
 import org.apache.kylin.common.util.ClassUtil;
 import org.apache.kylin.common.util.CliCommandExecutor;
 import org.apache.kylin.common.util.HadoopUtil;
+import org.apache.kylin.common.util.ZKBasedServerDiscovery;
 import org.apache.kylin.common.util.ZooKeeperUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1685,8 +1686,25 @@ abstract public class KylinConfigBase implements Serializable {
         return this.getOptional("kylin.server.mode", "all");
     }
 
+    public String getServerDiscoveryMode() {
+        return this.getOptional("kylin.server.discovery.mode", "default");
+    }
+
     public String[] getRestServers() {
-        return getOptionalStringArray("kylin.server.cluster-servers", new String[0]);
+        if (getServerDiscoveryMode().equals("zookeeper")) {
+            try {
+                return ZKBasedServerDiscovery.getInstance().getServers().toArray(new String[0]);
+            } catch (Exception e) {
+                logger.error("Failed to get servers from ZKBasedServerDiscovery", e);
+                return getOptionalStringArray("kylin.server.cluster-servers", new String[0]);
+            }
+        } else {
+            return getOptionalStringArray("kylin.server.cluster-servers", new String[0]);
+        }
+    }
+
+    public int getServerPort() {
+        return Integer.parseInt(getOptional("kylin.server.port", "7070"));
     }
 
     public String getClusterName() {

--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -1693,7 +1693,9 @@ abstract public class KylinConfigBase implements Serializable {
     public String[] getRestServers() {
         if (getServerDiscoveryMode().equals("zookeeper")) {
             try {
-                return ZKBasedServerDiscovery.getInstance().getServers().toArray(new String[0]);
+                List<String> servers = ZKBasedServerDiscovery.getInstance().getServers();
+                setProperty("kylin.server.cluster-servers", StringUtils.join(servers, ","));
+                return servers.toArray(new String[0]);
             } catch (Exception e) {
                 logger.error("Failed to get servers from ZKBasedServerDiscovery", e);
                 return getOptionalStringArray("kylin.server.cluster-servers", new String[0]);

--- a/core-common/src/main/java/org/apache/kylin/common/util/KylinInstanceDetail.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/KylinInstanceDetail.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.common.util;
+
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+@JsonRootName("detail")
+public class KylinInstanceDetail {
+  private String id;
+  private String listenAddress;
+
+  public KylinInstanceDetail(String id, String listenAddress) {
+    this.id = id;
+    this.listenAddress = listenAddress;
+  }
+
+  public KylinInstanceDetail() {
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getListenAddress() {
+    return listenAddress;
+  }
+
+  public void setListenAddress(String listenAddress) {
+    this.listenAddress = listenAddress;
+  }
+
+  @Override
+  public String toString() {
+    return "KylinInstanceDetail{" +
+        "id='" + id + '\'' +
+        ", listenAddress='" + listenAddress + '\'' +
+        '}';
+  }
+}

--- a/core-common/src/main/java/org/apache/kylin/common/util/ServerDiscovery.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/ServerDiscovery.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kylin.common.util;
+
+import java.util.List;
+
+public interface ServerDiscovery {
+
+  public boolean registerService() throws Exception;
+
+  public boolean unregisterService() throws Exception;
+
+  public List<String> getServers() throws Exception;
+
+  public void close();
+}

--- a/core-common/src/main/java/org/apache/kylin/common/util/ZKBasedServerDiscovery.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/ZKBasedServerDiscovery.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.common.util;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.x.discovery.ServiceCache;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
+import org.apache.kylin.common.KylinConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ZKBasedServerDiscovery implements ServerDiscovery {
+  private static final Logger logger = LoggerFactory.getLogger(ZKBasedServerDiscovery.class);
+  private static ZKBasedServerDiscovery INSTANCE = null;
+
+  public static ZKBasedServerDiscovery getInstance() throws Exception {
+    if (INSTANCE == null) {
+      INSTANCE = createInstance();
+    }
+    return INSTANCE;
+  }
+
+  public synchronized static ZKBasedServerDiscovery createInstance() throws Exception  {
+    destroyInstance();
+    INSTANCE = new ZKBasedServerDiscovery(KylinConfig.getInstanceFromEnv());
+    return INSTANCE;
+  }
+
+  public synchronized static void destroyInstance() {
+    ZKBasedServerDiscovery tmp = INSTANCE;
+    INSTANCE = null;
+    if (tmp != null) {
+      try {
+        tmp.close();
+      } catch (Exception e) {
+        logger.error("error stop ZKBasedServerDiscovery", e);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+
+  private CuratorFramework client;
+  private ServiceDiscovery<KylinInstanceDetail> serviceDiscovery;
+  private ServiceInstance<KylinInstanceDetail> instance;
+  private ServiceCache<KylinInstanceDetail> serviceCache;
+
+  public ZKBasedServerDiscovery(KylinConfig config) throws Exception {
+    client = CuratorFrameworkFactory.newClient(config.getZookeeperConnectString(),
+        new ExponentialBackoffRetry(1000, 3));
+    client.start();
+
+    JsonInstanceSerializer<KylinInstanceDetail> serializer = new JsonInstanceSerializer<KylinInstanceDetail>(KylinInstanceDetail.class);
+    serviceDiscovery = ServiceDiscoveryBuilder.builder(KylinInstanceDetail.class)
+        .client(client)
+        .serializer(serializer)
+        .basePath(config.getZookeeperBasePath())
+        .build();
+    serviceDiscovery.start();
+
+    serviceCache = serviceDiscovery.serviceCacheBuilder()
+        .name("servers")
+        .build();
+    serviceCache.start();
+
+    String host = InetAddress.getLocalHost().getHostName();
+    int port = config.getServerPort();
+
+    instance = ServiceInstance.<KylinInstanceDetail>builder()
+        .name("servers")
+        .address(host)
+        .port(port)
+        .payload(new KylinInstanceDetail(UUID.randomUUID().toString(), host + ":" + port))
+        .build();
+  }
+
+  @Override
+  public boolean registerService() throws Exception {
+    serviceDiscovery.registerService(instance);
+    logger.info("Register kylin server: " + instance);
+    return true;
+  }
+
+  @Override
+  public boolean unregisterService() throws Exception {
+    serviceDiscovery.unregisterService(instance);
+    logger.info("Unregister kylin server: " + instance);
+    return true;
+  }
+
+  @Override
+  public List<String> getServers() throws Exception {
+    List<String> servers = new ArrayList<String>();
+    for (ServiceInstance<KylinInstanceDetail> instance: serviceCache.getInstances()) {
+      servers.add(instance.getPayload().getListenAddress());
+    }
+    logger.info("Get kylin servers: " + servers);
+    return servers;
+  }
+
+  public void close() {
+    try {
+      serviceCache.close();
+      serviceDiscovery.close();
+      client.close();
+    } catch (Exception e) {
+      logger.error("Service discovery shutdown failed~", e);
+    }
+  }
+}

--- a/core-common/src/test/java/org/apache/kylin/common/util/ZKBasedServerDiscoveryTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/util/ZKBasedServerDiscoveryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.common.util;
+
+import org.apache.kylin.common.KylinConfig;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ZKBasedServerDiscoveryTest {
+  @Before
+  public void setUp() throws Exception {
+    HBaseMetadataTestCase.staticCreateTestMetadata();
+  }
+
+  @After
+  public void after() throws Exception {
+    HBaseMetadataTestCase.staticCleanupTestMetadata();
+  }
+
+  @Test
+  public void basicTest() throws Exception {
+    KylinConfig config = KylinConfig.getInstanceFromEnv();
+    ZKBasedServerDiscovery zkBasedServerDiscovery = new ZKBasedServerDiscovery(config);
+    Assert.assertEquals(0, zkBasedServerDiscovery.getServers().size());
+    zkBasedServerDiscovery.registerService();
+    Assert.assertEquals(1, zkBasedServerDiscovery.getServers().size());
+    zkBasedServerDiscovery.unregisterService();
+    Assert.assertEquals(0, zkBasedServerDiscovery.getServers().size());
+  }
+}

--- a/server-base/src/main/java/org/apache/kylin/rest/init/InitialTaskManager.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/init/InitialTaskManager.java
@@ -54,7 +54,6 @@ public class InitialTaskManager implements InitializingBean {
             try {
                 final ServerDiscovery serverDiscovery = ZKBasedServerDiscovery.createInstance();
                 serverDiscovery.registerService();
-
                 Runtime.getRuntime().addShutdownHook(new Thread() {
                     public void run() {
                         logger.info("Closing zookeeper based serverDiscovery");

--- a/server-base/src/main/java/org/apache/kylin/rest/init/InitialTaskManager.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/init/InitialTaskManager.java
@@ -20,6 +20,7 @@ package org.apache.kylin.rest.init;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.kylin.common.KylinConfig;
+import org.apache.kylin.common.util.ServerDiscovery;
 import org.apache.kylin.common.util.StringUtil;
 import org.apache.kylin.common.util.ZKBasedServerDiscovery;
 import org.apache.kylin.rest.metrics.QueryMetrics2Facade;

--- a/storage-hbase/src/test/java/org/apache/kylin/storage/hbase/util/ZookeeperAclBuilderTest.java
+++ b/storage-hbase/src/test/java/org/apache/kylin/storage/hbase/util/ZookeeperAclBuilderTest.java
@@ -76,7 +76,7 @@ public class ZookeeperAclBuilderTest extends LocalFileMetadataTestCase {
         Builder builder = zookeeperAclBuilder.setZKAclBuilder(CuratorFrameworkFactory.builder());
         Assert.assertNotNull(builder);
         Assert.assertEquals(zkAcls, builder.getAclProvider().getDefaultAcl());
-        Assert.assertNotNull(builder.getAuthInfos());
+        // Assert.assertNotNull(builder.getAuthInfos());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ZookeeperAclBuilderTest extends LocalFileMetadataTestCase {
         Builder builder = zookeeperAclBuilder.setZKAclBuilder(CuratorFrameworkFactory.builder());
         Assert.assertNotNull(builder);
         Assert.assertEquals(ZooDefs.Ids.OPEN_ACL_UNSAFE, builder.getAclProvider().getDefaultAcl());
-        Assert.assertNull(builder.getAuthInfos());
+        // Assert.assertNull(builder.getAuthInfos());
     }
 
 }

--- a/storage-hbase/src/test/java/org/apache/kylin/storage/hbase/util/ZookeeperAclBuilderTest.java
+++ b/storage-hbase/src/test/java/org/apache/kylin/storage/hbase/util/ZookeeperAclBuilderTest.java
@@ -76,7 +76,7 @@ public class ZookeeperAclBuilderTest extends LocalFileMetadataTestCase {
         Builder builder = zookeeperAclBuilder.setZKAclBuilder(CuratorFrameworkFactory.builder());
         Assert.assertNotNull(builder);
         Assert.assertEquals(zkAcls, builder.getAclProvider().getDefaultAcl());
-        // Assert.assertNotNull(builder.getAuthInfos());
+        Assert.assertNotNull(builder.getAuthInfos());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ZookeeperAclBuilderTest extends LocalFileMetadataTestCase {
         Builder builder = zookeeperAclBuilder.setZKAclBuilder(CuratorFrameworkFactory.builder());
         Assert.assertNotNull(builder);
         Assert.assertEquals(ZooDefs.Ids.OPEN_ACL_UNSAFE, builder.getAclProvider().getDefaultAcl());
-        // Assert.assertNull(builder.getAuthInfos());
+        Assert.assertNull(builder.getAuthInfos());
     }
 
 }


### PR DESCRIPTION
Currently to broadcast config or meta changes, all kylin servers must be set in kylin.properties. It's not convenient when adding or removing kylin server especially in k8s env.
 
So we can register the endpoint to zk and make the rest server discovery  automatically.
