### PR TITLE
KYLIN-3822 fix the param parse error in DeployCoprocessorCLI

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
@@ -98,20 +98,19 @@ public class DeployCoprocessorCLI {
             hbaseAdmin = conn.getAdmin();
             String localCoprocessorJar;
             int curIdx = 0;
-            if ("default".equals(args[curIdx++])) {
+            if ("default".equals(args[curIdx])) {
                 localCoprocessorJar = kylinConfig.getCoprocessorLocalJar();
             } else {
-                curIdx--;
-                localCoprocessorJar = new File(args[curIdx++]).getAbsolutePath();
+                localCoprocessorJar = new File(args[curIdx]).getAbsolutePath();
             }
-
+            curIdx++;
             logger.info("Identify coprocessor jar " + localCoprocessorJar);
 
             try {
-                MAX_THREADS = Integer.parseInt(args[curIdx++]);
+                MAX_THREADS = Integer.parseInt(args[curIdx]);
             } catch (Exception e) {
-                curIdx--;
             }
+            curIdx++;
             logger.info("Use at most {} threads to do upgrade", MAX_THREADS);
 
             List<String> tableNames = getHTableNames(kylinConfig);

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
@@ -101,7 +101,8 @@ public class DeployCoprocessorCLI {
             if ("default".equals(args[curIdx++])) {
                 localCoprocessorJar = kylinConfig.getCoprocessorLocalJar();
             } else {
-                localCoprocessorJar = new File(args[curIdx]).getAbsolutePath();
+                curIdx--;
+                localCoprocessorJar = new File(args[curIdx++]).getAbsolutePath();
             }
 
             logger.info("Identify coprocessor jar " + localCoprocessorJar);

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/DeployCoprocessorCLI.java
@@ -109,6 +109,7 @@ public class DeployCoprocessorCLI {
             try {
                 MAX_THREADS = Integer.parseInt(args[curIdx]);
             } catch (Exception e) {
+                
             }
             curIdx++;
             logger.info("Use at most {} threads to do upgrade", MAX_THREADS);


### PR DESCRIPTION
bugfix KYLIN-3822
101行运行完之后，curIdx的值为1，如果101行表达式为false，则args[curIdx]取到的参数为第二个参数，非第一个参数（第一个参数才代表localCoprocessorJar的地址）