### PR TITLE
KYLIN-3824

### DIFF
--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkFactDistinct.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkFactDistinct.java
@@ -310,12 +310,12 @@ public class SparkFactDistinct extends AbstractApplication implements Serializab
                 }
             }
 
-            List<String[]> rows = Lists.newArrayList(rowIterator);
             List<Tuple2<SelfDefineSortableKey, Text>> result = Lists.newArrayList();
 
             int rowCount = 0;
 
-            for (String[] row : rows) {
+            while (rowIterator.hasNext()) {
+                String[] row = rowIterator.next();
                 bytesWritten.add(countSizeInBytes(row));
 
                 for (int i = 0; i < allCols.size(); i++) {


### PR DESCRIPTION
For environment with low RAM, and huge Cube, remove List to avoid java.lang.OutOfMemory and iterate by Iterator.