### PR TITLE
KYLIN-3727 Check if where is no directories, then finish job successf…

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/BulkLoadJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/BulkLoadJob.java
@@ -22,9 +22,13 @@ import java.io.IOException;
 
 import org.apache.commons.cli.Options;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsShell;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles;
 import org.apache.hadoop.util.ToolRunner;
+import org.apache.kylin.common.util.HadoopUtil;
 import org.apache.kylin.engine.mr.MRUtil;
 import org.apache.kylin.engine.mr.common.AbstractHadoopJob;
 import org.apache.kylin.storage.hbase.HBaseConnection;
@@ -74,10 +78,27 @@ public class BulkLoadJob extends AbstractHadoopJob {
         newArgs[0] = input;
         newArgs[1] = tableName;
 
-        logger.debug("Start to run LoadIncrementalHFiles");
-        int ret = MRUtil.runMRJob(new LoadIncrementalHFiles(conf), newArgs);
-        logger.debug("End to run LoadIncrementalHFiles");
-        return ret;
+        int count = 0;
+        Path inputPath = new Path(input);
+        FileSystem fs = HadoopUtil.getFileSystem(inputPath);
+        FileStatus[] fileStatuses = fs.listStatus(inputPath);
+        for(FileStatus fileStatus: fileStatuses) {
+            if(fileStatus.isDirectory()) {
+                count++;
+                break;
+            }
+        }
+
+        int ret = 0;
+        if (count > 0) {
+            logger.debug("Start to run LoadIncrementalHFiles");
+            ret = MRUtil.runMRJob(new LoadIncrementalHFiles(conf), newArgs);
+            logger.debug("End to run LoadIncrementalHFiles");
+            return ret;
+        } else {
+            logger.debug("Nothing to load, cube is empty");
+            return ret;
+        }
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
…ully.

Input path for HBase load consists
_SUCCESS
F1
F2
etc...

So, check if no folders exist, then skip loading step.

Test for non-empty cube:
2019-02-28 14:56:20,333 INFO  [Scheduler 136668115 Job 0143a095-92fe-c8e0-a919-428682e2f15d-238] execution.ExecutableManager:453 : job id:0143a095-92fe-c8e0-a919-428682e2f15d-08 from READY to RUNNING
2019-02-28 14:56:20,354 INFO  [Scheduler 136668115 Job 0143a095-92fe-c8e0-a919-428682e2f15d-238] common.HadoopShellExecutable:59 : parameters of the HadoopShellExecutable:  -input hdfs://***:8020/kylin/kylin_metadata/kylin-0143a095-92fe-c8e0-a919-428682e2f15d/ORCTESTCUBE/hfile -htablename KYLIN_D9OV6ZF44W -cubename ORCTESTCUBE
2019-02-28 14:56:25,416 DEBUG [Scheduler 136668115 Job 0143a095-92fe-c8e0-a919-428682e2f15d-238] steps.BulkLoadJob:95 : Start to run LoadIncrementalHFiles

Test in my env for empty cube:
2019-02-28 14:42:15,699 INFO  [Scheduler 136668115 Job 199180ac-8ab3-708f-c89c-6f2166a7d27d-102] execution.ExecutableManager:453 : job id:199180ac-8ab3-708f-c89c-6f2166a7d27d-08 from READY to RUNNING
2019-02-28 14:42:15,784 INFO  [Scheduler 136668115 Job 199180ac-8ab3-708f-c89c-6f2166a7d27d-102] common.HadoopShellExecutable:59 : parameters of the HadoopShellExecutable:  -input hdfs://***:8020/kylin/kylin_metadata/kylin-199180ac-8ab3-708f-c89c-6f2166a7d27d/kylin_sales_cube_orc/hfile -htablename KYLIN_MP2UWUVS0X -cubename kylin_sales_cube_orc
2019-02-28 14:42:21,402 DEBUG [Scheduler 136668115 Job 199180ac-8ab3-708f-c89c-6f2166a7d27d-102] steps.BulkLoadJob:100 : Nothing to load, cube is empty
