### PR TITLE
KYLIN-3830 return wrong result when 'SELECT SUM(dim1)' without set a …

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/metadata/model/FunctionDesc.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/model/FunctionDesc.java
@@ -68,7 +68,6 @@ public class FunctionDesc implements Serializable {
         BUILT_IN_AGGREGATIONS.add(FUNC_COUNT);
         BUILT_IN_AGGREGATIONS.add(FUNC_MAX);
         BUILT_IN_AGGREGATIONS.add(FUNC_MIN);
-        BUILT_IN_AGGREGATIONS.add(FUNC_SUM);
         BUILT_IN_AGGREGATIONS.add(FUNC_COUNT_DISTINCT);
         BUILT_IN_AGGREGATIONS.add(FUNC_PERCENTILE);
     }


### PR DESCRIPTION
just remove FUNC_SUM in BUILT_IN_AGGREGATIONS, which make the kylin doesn't support query sum(dim1) without set a relative metric of dim1