### PR TITLE
KYLIN-3817: Duration in Cube building is a negative number

### DIFF
--- a/core-job/src/main/java/org/apache/kylin/job/execution/DefaultChainedExecutable.java
+++ b/core-job/src/main/java/org/apache/kylin/job/execution/DefaultChainedExecutable.java
@@ -77,14 +77,14 @@ public class DefaultChainedExecutable extends AbstractExecutable implements Chai
     @Override
     protected void onExecuteStart(ExecutableContext executableContext) {
         final long startTime = getStartTime();
-        Map<String, String> info = Maps.newHashMap();
-        info.put(BUILD_INSTANCE, DistributedLockFactory.processAndHost());
         if (startTime > 0) {
-            getManager().updateJobOutput(getId(), ExecutableState.RUNNING, info, null);
+            getManager().updateJobOutput(getId(), ExecutableState.RUNNING, null, null);
         } else {
+            Map<String, String> info = Maps.newHashMap();
             info.put(START_TIME, Long.toString(System.currentTimeMillis()));
             getManager().updateJobOutput(getId(), ExecutableState.RUNNING, info, null);
         }
+        getManager().addJobInfo(getId(), BUILD_INSTANCE, DistributedLockFactory.processAndHost());
     }
 
     @Override

--- a/core-job/src/main/java/org/apache/kylin/job/execution/ExecutableManager.java
+++ b/core-job/src/main/java/org/apache/kylin/job/execution/ExecutableManager.java
@@ -444,7 +444,7 @@ public class ExecutableManager {
                 jobOutput.setStatus(newStatus.toString());
             }
             if (info != null) {
-                jobOutput.getInfo().putAll(info);
+                jobOutput.setInfo(info);
             }
             if (output != null) {
                 jobOutput.setContent(output);


### PR DESCRIPTION
See KYLIN-3817.

After building the cube for a few minutes, click the Refresh button and the duration of the job becomes negative.

This bug is introduced in KYLIN-3780: https://github.com/apache/kylin/pull/442/commits/b3728040e39bf32412624907e493f666c49dfb5c