### PR TITLE
KYLIN-3880: DataType is incompatible in Kylin HBase coprocessor

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/metadata/datatype/DataType.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/datatype/DataType.java
@@ -40,9 +40,8 @@ import org.apache.kylin.metadata.model.TblColRef.InnerDataTypeEnum;
 
 /**
  */
-@SuppressWarnings("serial")
 public class DataType implements Serializable {
-
+    private static final long serialVersionUID = -8891652700267537109L;
     private static final LinkedHashSet<String> VALID_TYPES = new LinkedHashSet<String>();
     private static final LinkedHashSet<String> COMPLEX_TYPES = new LinkedHashSet<String>();
 


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3880
