### PR TITLE
KYLIN-3884: loading hfile to HBase failed for temporary dir in output path

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/BulkLoadJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/BulkLoadJob.java
@@ -88,6 +88,7 @@ public class BulkLoadJob extends AbstractHadoopJob {
             if (fileStatus.isDirectory()) {
                 Path path = fileStatus.getPath();
                 if (path.getName().equals(FileOutputCommitter.TEMP_DIR_NAME)) {
+                    logger.info("Delete temporary path: " + path);
                     fs.delete(path, true);
                 } else {
                     count++;

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/BulkLoadJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/BulkLoadJob.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsShell;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles;
+import org.apache.hadoop.mapred.FileOutputCommitter;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.kylin.common.util.HadoopUtil;
 import org.apache.kylin.engine.mr.MRUtil;
@@ -82,10 +83,15 @@ public class BulkLoadJob extends AbstractHadoopJob {
         Path inputPath = new Path(input);
         FileSystem fs = HadoopUtil.getFileSystem(inputPath);
         FileStatus[] fileStatuses = fs.listStatus(inputPath);
-        for(FileStatus fileStatus: fileStatuses) {
-            if(fileStatus.isDirectory()) {
-                count++;
-                break;
+
+        for (FileStatus fileStatus : fileStatuses) {
+            if (fileStatus.isDirectory()) {
+                Path path = fileStatus.getPath();
+                if (path.getName().equals(FileOutputCommitter.TEMP_DIR_NAME)) {
+                    fs.delete(path, true);
+                } else {
+                    count++;
+                }
             }
         }
 


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3884

Delete the temporary dir before loading hfiles to HBase tables.