### PR TITLE
KYLIN-3886:  Missing argument for options for yarn command

### DIFF
--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java
@@ -303,7 +303,7 @@ public class SparkExecutable extends AbstractExecutable {
                     executorService.shutdownNow(); // interrupt
                     extra = mgr.getOutput(getId()).getExtra();
                     if (extra != null) {
-                        String  newJobId = extra.get(ExecutableConstants.SPARK_JOB_ID);
+                        String newJobId = extra.get(ExecutableConstants.SPARK_JOB_ID);
                         if (StringUtils.isNotEmpty(newJobId)) {
                             killAppRetry(newJobId);
                         }


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3886

The app id may be empty which cause the yarn command failed for missing argument.
Checking the app id before executing yarn command