### PR TITLE
KYLIN-3888 TableNotDisabledException when running "Convert Lookup Table to HFile"

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/lookup/LookupTableToHFileJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/lookup/LookupTableToHFileJob.java
@@ -165,9 +165,7 @@ public class LookupTableToHFileJob extends AbstractHadoopJob {
         extSnapshotInfoManager.removeSnapshot(tableName, lookupSnapshotID);
         String hTableName = snapshotInfo.getStorageLocationIdentifier();
         logger.info("remove related HBase table:{} for snapshot:{}", hTableName, lookupSnapshotID);
-        Connection conn = getHBaseConnection(kylinConfig);
-        Admin admin = conn.getAdmin();
-        admin.deleteTable(TableName.valueOf(hTableName));
+        HBaseConnection.deleteTable(kylinConfig.getStorageUrl(), hTableName);
     }
 
     private String[] getLookupKeyColumns(CubeInstance cube, String tableName) {


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3888