### PR TITLE
 KYLIN-3885: Build dimension dictionary job costs too long when using Spark fact distinct

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -1985,4 +1985,8 @@ public abstract class KylinConfigBase implements Serializable {
     public boolean isLimitPushDownEnabled() {
         return Boolean.parseBoolean(getOptional("kylin.storage.limit-push-down-enabled", TRUE));
     }
+
+    public boolean isSparkFactDistinctEnable() {
+        return Boolean.parseBoolean(getOptional("kylin.engine.spark-fact-distinct", "false"));
+    }
 }

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/global/AppendTrieDictionaryBuilder.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/global/AppendTrieDictionaryBuilder.java
@@ -22,6 +22,8 @@ import org.apache.kylin.common.util.BytesUtil;
 import org.apache.kylin.dict.AppendTrieDictionary;
 import org.apache.kylin.dict.BytesConverter;
 import org.apache.kylin.dict.StringBytesConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,7 +32,7 @@ import java.util.TreeMap;
 import static com.google.common.base.Preconditions.checkState;
 
 public class AppendTrieDictionaryBuilder {
-
+    private static Logger logger = LoggerFactory.getLogger(AppendTrieDictionaryBuilder.class);
     private final String baseDir;
     private final String workingDir;
     private final int maxEntriesPerSlice;
@@ -45,6 +47,7 @@ public class AppendTrieDictionaryBuilder {
 
     private AppendDictSliceKey curKey;
     private AppendDictNode curNode;
+    private AppendDictSliceKey preKey;
 
     public AppendTrieDictionaryBuilder(String baseDir, int maxEntriesPerSlice, boolean isAppendDictGlobal) throws IOException {
         this.baseDir = baseDir;
@@ -86,7 +89,13 @@ public class AppendTrieDictionaryBuilder {
         }
         checkState(sliceFileMap.firstKey().equals(AppendDictSliceKey.START_KEY), "first key should be \"\", but got \"%s\"", sliceFileMap.firstKey());
 
-        AppendDictSliceKey nextKey = sliceFileMap.floorKey(AppendDictSliceKey.wrap(valueBytes));
+        AppendDictSliceKey key = AppendDictSliceKey.wrap(valueBytes);
+        if (preKey != null && key.compareTo(preKey) < 0) {
+            logger.warn("Current key: " + key + " is less than preview key: " + preKey
+                + ", which may cost too many slice file flush/delete/read operations");
+        }
+        preKey = key;
+        AppendDictSliceKey nextKey = sliceFileMap.floorKey(key);
 
         if (curKey != null && !nextKey.equals(curKey)) {
             // you may suppose nextKey>=curKey, but nextKey<curKey could happen when a node splits.

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/global/AppendTrieDictionaryBuilder.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/global/AppendTrieDictionaryBuilder.java
@@ -22,8 +22,6 @@ import org.apache.kylin.common.util.BytesUtil;
 import org.apache.kylin.dict.AppendTrieDictionary;
 import org.apache.kylin.dict.BytesConverter;
 import org.apache.kylin.dict.StringBytesConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +30,6 @@ import java.util.TreeMap;
 import static com.google.common.base.Preconditions.checkState;
 
 public class AppendTrieDictionaryBuilder {
-    private static Logger logger = LoggerFactory.getLogger(AppendTrieDictionaryBuilder.class);
     private final String baseDir;
     private final String workingDir;
     private final int maxEntriesPerSlice;
@@ -47,7 +44,6 @@ public class AppendTrieDictionaryBuilder {
 
     private AppendDictSliceKey curKey;
     private AppendDictNode curNode;
-    private AppendDictSliceKey preKey;
 
     public AppendTrieDictionaryBuilder(String baseDir, int maxEntriesPerSlice, boolean isAppendDictGlobal) throws IOException {
         this.baseDir = baseDir;
@@ -89,13 +85,7 @@ public class AppendTrieDictionaryBuilder {
         }
         checkState(sliceFileMap.firstKey().equals(AppendDictSliceKey.START_KEY), "first key should be \"\", but got \"%s\"", sliceFileMap.firstKey());
 
-        AppendDictSliceKey key = AppendDictSliceKey.wrap(valueBytes);
-        if (preKey != null && key.compareTo(preKey) < 0) {
-            logger.warn("Current key: " + key + " is less than preview key: " + preKey
-                + ", which may cost too many slice file flush/delete/read operations");
-        }
-        preKey = key;
-        AppendDictSliceKey nextKey = sliceFileMap.floorKey(key);
+        AppendDictSliceKey nextKey = sliceFileMap.floorKey(AppendDictSliceKey.wrap(valueBytes));
 
         if (curKey != null && !nextKey.equals(curKey)) {
             // you may suppose nextKey>=curKey, but nextKey<curKey could happen when a node splits.

--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkBatchCubingJobBuilder2.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkBatchCubingJobBuilder2.java
@@ -61,7 +61,12 @@ public class SparkBatchCubingJobBuilder2 extends JobBuilderSupport {
         inputSide.addStepPhase1_CreateFlatTable(result);
 
         // Phase 2: Build Dictionary
-        result.addTask(createFactDistinctColumnsSparkStep(jobId));
+        KylinConfig config = KylinConfig.getInstanceFromEnv();
+        if (config.isSparkFactDistinctEnable()) {
+            result.addTask(createFactDistinctColumnsSparkStep(jobId));
+        } else {
+            result.addTask(createFactDistinctColumnsStep(jobId));
+        }
 
         if (isEnableUHCDictStep()) {
             result.addTask(createBuildUHCDictStep(jobId));


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3893

The issue is that the ColumnDFSFile generated by Spark fact distinct is not sorted, which cause too many write/delete/read slice files when building global dictionary.