### PR TITLE
KYLIN-3905 Enable shrunken dictionary default

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -542,7 +542,7 @@ public abstract class KylinConfigBase implements Serializable {
     }
 
     public boolean isShrunkenDictFromGlobalEnabled() {
-        return Boolean.parseBoolean(this.getOptional("kylin.dictionary.shrunken-from-global-enabled", FALSE));
+        return Boolean.parseBoolean(this.getOptional("kylin.dictionary.shrunken-from-global-enabled", TRUE));
     }
 
     // ============================================================================


### PR DESCRIPTION
In dev mail list's discussion, I suggest to enable shrunken dictionary by default, and received some dev's aggrement. 
When using bitmap measure on a large cardinality column(require global dictionaty), build base cuboid step need frequent cache swap so it cannot finished within a reasonable period.
When shrunken dictionary enabled, a new step will be added to build separated dictionary for each `InputSplit`, Mapper of *BuildBaseCuboid* step only has to fetch a smaller dictionary for itself, instead of a larger global dictionary. It will reduce cache swap and make *BuildBaseCuboid* step run as quicker as possible.