### PR TITLE
KYLIN-3908 KylinClient's HttpRequest.releaseConnection is not needed in retrieveMetaData & executeKylinQuery

### DIFF
--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinClient.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinClient.java
@@ -310,7 +310,6 @@ public class KylinClient implements IRemoteClient {
         List<KMetaTable> tables = convertMetaTables(tableMetaStubs);
         List<KMetaSchema> schemas = convertMetaSchemas(tables);
         List<KMetaCatalog> catalogs = convertMetaCatalogs(schemas);
-        get.releaseConnection();
         return new KMetaProject(project, catalogs);
     }
 
@@ -432,7 +431,6 @@ public class KylinClient implements IRemoteClient {
         }
 
         SQLResponseStub stub = jsonMapper.readValue(response.getEntity().getContent(), SQLResponseStub.class);
-        post.releaseConnection();
         return stub;
     }
 

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinClient.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinClient.java
@@ -298,19 +298,21 @@ public class KylinClient implements IRemoteClient {
         addHttpHeaders(get);
 
         HttpResponse response = httpClient.execute(get);
+        try {
+            if (response.getStatusLine().getStatusCode() != 200 && response.getStatusLine().getStatusCode() != 201) {
+                throw asIOException(get, response);
+            }
 
-        if (response.getStatusLine().getStatusCode() != 200 && response.getStatusLine().getStatusCode() != 201) {
-            throw asIOException(get, response);
+            List<TableMetaStub> tableMetaStubs = jsonMapper.readValue(response.getEntity().getContent(),
+                    new TypeReference<List<TableMetaStub>>() {
+                    });
+            List<KMetaTable> tables = convertMetaTables(tableMetaStubs);
+            List<KMetaSchema> schemas = convertMetaSchemas(tables);
+            List<KMetaCatalog> catalogs = convertMetaCatalogs(schemas);
+            return new KMetaProject(project, catalogs);
+        } finally {
+           get.releaseConnection(); 
         }
-
-        List<TableMetaStub> tableMetaStubs = jsonMapper.readValue(response.getEntity().getContent(),
-                new TypeReference<List<TableMetaStub>>() {
-                });
-
-        List<KMetaTable> tables = convertMetaTables(tableMetaStubs);
-        List<KMetaSchema> schemas = convertMetaSchemas(tables);
-        List<KMetaCatalog> catalogs = convertMetaCatalogs(schemas);
-        return new KMetaProject(project, catalogs);
     }
 
     private List<KMetaCatalog> convertMetaCatalogs(List<KMetaSchema> schemas) {
@@ -425,13 +427,16 @@ public class KylinClient implements IRemoteClient {
         post.setEntity(requestEntity);
 
         HttpResponse response = httpClient.execute(post);
+        try {
+            if (response.getStatusLine().getStatusCode() != 200 && response.getStatusLine().getStatusCode() != 201) {
+                throw asIOException(post, response);
+            }
 
-        if (response.getStatusLine().getStatusCode() != 200 && response.getStatusLine().getStatusCode() != 201) {
-            throw asIOException(post, response);
+            SQLResponseStub stub = jsonMapper.readValue(response.getEntity().getContent(), SQLResponseStub.class);
+            return stub;
+        } finally {
+            post.releaseConnection();
         }
-
-        SQLResponseStub stub = jsonMapper.readValue(response.getEntity().getContent(), SQLResponseStub.class);
-        return stub;
     }
 
     private List<ColumnMetaData> convertColumnMeta(SQLResponseStub queryResp) {


### PR DESCRIPTION
This update intends to make the code to handle HTTP connection releasing not confusing. 
Issue description is at https://issues.apache.org/jira/browse/KYLIN-3908