### PR TITLE
KYLIN-3913: Remove getAllOutputs api in ExecutableManager to avoid OOM for large metadata

### DIFF
--- a/core-job/src/main/java/org/apache/kylin/job/execution/ExecutableManager.java
+++ b/core-job/src/main/java/org/apache/kylin/job/execution/ExecutableManager.java
@@ -23,7 +23,6 @@ import static org.apache.kylin.job.constant.ExecutableConstants.YARN_APP_ID;
 import static org.apache.kylin.job.constant.ExecutableConstants.YARN_APP_URL;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Locale;
@@ -189,44 +188,6 @@ public class ExecutableManager {
         return result;
     }
 
-    public Map<String, Output> getAllOutputs() {
-        try {
-            final List<ExecutableOutputPO> jobOutputs = executableDao.getJobOutputs();
-            HashMap<String, Output> result = Maps.newHashMap();
-            for (ExecutableOutputPO jobOutput : jobOutputs) {
-                result.put(jobOutput.getId(), parseOutput(jobOutput));
-            }
-            return result;
-        } catch (PersistentException e) {
-            logger.error("fail to get all job output:", e);
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Map<String, Output> getAllOutputs(long timeStartInMillis, long timeEndInMillis) {
-        try {
-            final List<ExecutableOutputPO> jobOutputs = executableDao.getJobOutputs(timeStartInMillis, timeEndInMillis);
-            HashMap<String, Output> result = Maps.newHashMap();
-            for (ExecutableOutputPO jobOutput : jobOutputs) {
-                result.put(jobOutput.getId(), parseOutput(jobOutput));
-            }
-            return result;
-        } catch (PersistentException e) {
-            logger.error("fail to get all job output:", e);
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Map<String, ExecutableOutputPO> getAllOutputDigests(long timeStartInMillis, long timeEndInMillis) {
-        final List<ExecutableOutputPO> jobOutputs = executableDao.getJobOutputDigests(timeStartInMillis,
-                timeEndInMillis);
-        HashMap<String, ExecutableOutputPO> result = Maps.newHashMap();
-        for (ExecutableOutputPO jobOutput : jobOutputs) {
-            result.put(jobOutput.getId(), jobOutput);
-        }
-        return result;
-    }
-
     public List<AbstractExecutable> getAllExecutables() {
         try {
             List<AbstractExecutable> ret = Lists.newArrayList();
@@ -354,7 +315,7 @@ public class ExecutableManager {
             final long endTime = job.getEndTime();
             if (endTime != 0) {
                 long interruptTime = System.currentTimeMillis() - endTime + job.getInterruptTime();
-                info = Maps.newHashMap(getJobOutput(jobId).getInfo());
+                info = Maps.newHashMap(getOutput(jobId).getExtra());
                 info.put(AbstractExecutable.INTERRUPT_TIME, Long.toString(interruptTime));
                 info.remove(AbstractExecutable.END_TIME);
             }
@@ -417,14 +378,6 @@ public class ExecutableManager {
         updateJobOutput(jobId, ExecutableState.STOPPED, null, null);
     }
 
-    public ExecutableOutputPO getJobOutput(String jobId) {
-        try {
-            return executableDao.getJobOutput(jobId);
-        } catch (PersistentException e) {
-            logger.error("Can't get output of Job " + jobId);
-            throw new RuntimeException(e);
-        }
-    }
 
     public void updateJobOutput(String jobId, ExecutableState newStatus, Map<String, String> info, String output) {
         // when 

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/common/JobInfoConverter.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/common/JobInfoConverter.java
@@ -31,10 +31,10 @@ import org.apache.kylin.job.JobSearchResult;
 import org.apache.kylin.job.common.ShellExecutable;
 import org.apache.kylin.job.constant.JobStatusEnum;
 import org.apache.kylin.job.constant.JobStepStatusEnum;
-import org.apache.kylin.job.dao.ExecutableOutputPO;
 import org.apache.kylin.job.execution.AbstractExecutable;
 import org.apache.kylin.job.execution.CheckpointExecutable;
 import org.apache.kylin.job.execution.DefaultChainedExecutable;
+import org.apache.kylin.job.execution.ExecutableManager;
 import org.apache.kylin.job.execution.ExecutableState;
 import org.apache.kylin.job.execution.Output;
 import org.slf4j.Logger;
@@ -43,31 +43,31 @@ import org.slf4j.LoggerFactory;
 public class JobInfoConverter {
     private static final Logger logger = LoggerFactory.getLogger(JobInfoConverter.class);
 
-    public static JobInstance parseToJobInstanceQuietly(CubingJob job, Map<String, Output> outputs) {
+    public static JobInstance parseToJobInstanceQuietly(CubingJob job) {
         try {
-            return parseToJobInstance(job, outputs);
+            return parseToJobInstance(job);
         } catch (Exception e) {
             logger.error("Failed to parse job instance: uuid={}", job, e);
             return null;
         }
     }
 
-    public static JobInstance parseToJobInstanceQuietly(CheckpointExecutable job, Map<String, Output> outputs) {
+    public static JobInstance parseToJobInstanceQuietly(CheckpointExecutable job) {
         try {
-            return parseToJobInstance(job, outputs);
+            return parseToJobInstance(job);
         } catch (Exception e) {
             logger.error("Failed to parse job instance: uuid={}", job, e);
             return null;
         }
     }
 
-    public static JobInstance parseToJobInstance(CubingJob job, Map<String, Output> outputs) {
+    public static JobInstance parseToJobInstance(CubingJob job) {
         if (job == null) {
             logger.warn("job is null.");
             return null;
         }
-
-        Output output = outputs.get(job.getId());
+        ExecutableManager executableManager = ExecutableManager.getInstance(KylinConfig.getInstanceFromEnv());
+        Output output = executableManager.getOutput(job.getId());
         if (output == null) {
             logger.warn("job output is null.");
             return null;
@@ -96,18 +96,18 @@ public class JobInfoConverter {
                 result.getExecInterruptTime()) / 1000);
         for (int i = 0; i < job.getTasks().size(); ++i) {
             AbstractExecutable task = job.getTasks().get(i);
-            result.addStep(parseToJobStep(task, i, outputs.get(task.getId())));
+            result.addStep(parseToJobStep(task, i, executableManager.getOutput(task.getId())));
         }
         return result;
     }
 
-    public static JobInstance parseToJobInstance(CheckpointExecutable job, Map<String, Output> outputs) {
+    public static JobInstance parseToJobInstance(CheckpointExecutable job) {
         if (job == null) {
             logger.warn("job is null.");
             return null;
         }
-
-        Output output = outputs.get(job.getId());
+        ExecutableManager executableManager = ExecutableManager.getInstance(KylinConfig.getInstanceFromEnv());
+        Output output = executableManager.getOutput(job.getId());
         if (output == null) {
             logger.warn("job output is null.");
             return null;
@@ -130,7 +130,7 @@ public class JobInfoConverter {
                 result.getExecInterruptTime()) / 1000);
         for (int i = 0; i < job.getTasks().size(); ++i) {
             AbstractExecutable task = job.getTasks().get(i);
-            result.addStep(parseToJobStep(task, i, outputs.get(task.getId())));
+            result.addStep(parseToJobStep(task, i, executableManager.getOutput(task.getId())));
         }
         return result;
     }
@@ -207,13 +207,13 @@ public class JobInfoConverter {
         }
     }
 
-    public static JobSearchResult parseToJobSearchResult(DefaultChainedExecutable job, Map<String, ExecutableOutputPO> outputs) {
+    public static JobSearchResult parseToJobSearchResult(DefaultChainedExecutable job) {
         if (job == null) {
             logger.warn("job is null.");
             return null;
         }
-
-        ExecutableOutputPO output = outputs.get(job.getId());
+        ExecutableManager executableManager = ExecutableManager.getInstance(KylinConfig.getInstanceFromEnv());
+        Output output = executableManager.getOutput(job.getId());
         if (output == null) {
             logger.warn("job output is null.");
             return null;

--- a/engine-mr/src/test/java/org/apache/kylin/engine/mr/common/JobInfoConverterTest.java
+++ b/engine-mr/src/test/java/org/apache/kylin/engine/mr/common/JobInfoConverterTest.java
@@ -37,7 +37,7 @@ public class JobInfoConverterTest {
     @Test
     public void testParseToJobInstance() {
         TestJob task = new TestJob();
-        JobInstance instance = JobInfoConverter.parseToJobInstanceQuietly(task, Maps.<String, Output> newHashMap());
+        JobInstance instance = JobInfoConverter.parseToJobInstanceQuietly(task);
         // no exception thrown is expected
         Assert.assertTrue(instance == null);
     }

--- a/server/src/test/java/org/apache/kylin/rest/service/JobServiceTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/service/JobServiceTest.java
@@ -27,7 +27,6 @@ import org.apache.kylin.job.execution.ExecutableContext;
 import org.apache.kylin.job.execution.ExecutableManager;
 import org.apache.kylin.job.execution.ExecutableState;
 import org.apache.kylin.job.execution.ExecuteResult;
-import org.apache.kylin.job.execution.Output;
 import org.apache.kylin.metadata.project.ProjectInstance;
 import org.apache.kylin.query.QueryConnection;
 import org.junit.Assert;
@@ -69,8 +68,7 @@ public class JobServiceTest extends ServiceTestBase {
         AbstractExecutable executable = new TestJob();
         manager.addJob(executable);
         List<CubingJob> jobs = jobService.innerSearchCubingJobs("cube", "jobName",
-                Collections.<ExecutableState> emptySet(), 0, Long.MAX_VALUE, Collections.<String, Output> emptyMap(),
-                true, "project");
+                Collections.<ExecutableState> emptySet(), 0, Long.MAX_VALUE, true, "project");
         Assert.assertEquals(0, jobs.size());
     }
 


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3913