### PR TITLE
KYLIN-3936 MR/Spark task will still run after the job is stopped

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/JobController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/JobController.java
@@ -180,7 +180,8 @@ public class JobController extends BasicController {
 
         try {
             final JobInstance jobInstance = jobService.getJobInstance(jobId);
-            return jobService.pauseJob(jobInstance);
+            jobService.pauseJob(jobInstance);
+            return jobService.getJobInstance(jobId);
         } catch (Exception e) {
             logger.error(e.getLocalizedMessage(), e);
             throw new InternalErrorException(e);

--- a/server-base/src/main/java/org/apache/kylin/rest/service/JobService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/JobService.java
@@ -658,11 +658,15 @@ public class JobService extends BasicService implements InitializingBean {
         }
     }
 
-    public JobInstance pauseJob(JobInstance job) {
+    public void pauseJob(JobInstance job) {
         aclEvaluate.checkProjectOperationPermission(job);
+        logger.info("Pause job [" + job.getId() + "] trigger by "
+            + SecurityContextHolder.getContext().getAuthentication().getName());
+        if (job.getStatus().isComplete()) {
+          throw new IllegalStateException(
+              "The job " + job.getId() + " has already been finished and cannot be stopped.");
+        }
         getExecutableManager().pauseJob(job.getId());
-        job.setStatus(JobStatusEnum.STOPPED);
-        return job;
     }
 
     public void dropJob(JobInstance job) {


### PR DESCRIPTION
The command "pause" only sets status of the job to "stopped" and does not reset the status of the subtask.https://github.com/apache/kylin/blob/e9dfaf9a5465ff3f6f3bfa3460ca8b2adb8c6617/server-base/src/main/java/org/apache/kylin/rest/service/JobService.java#L662-L666
So, In SparkExecutable, we can't get the real status of the running task. https://github.com/apache/kylin/blob/e9dfaf9a5465ff3f6f3bfa3460ca8b2adb8c6617/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java#L293-L300