### PR TITLE
KYLIN-3932 KafkaConfigOverride to take effect

### DIFF
--- a/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/KafkaSource.java
+++ b/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/KafkaSource.java
@@ -245,7 +245,12 @@ public class KafkaSource implements IStreamingSource {
     }
 
     public static Map<String, Object> getKafkaConf(Map<String, String> sourceProperties, KylinConfig kylinConfig) {
-        return getKafkaConf(sourceProperties);
+        Map<String, String> kafkaConfigOverride = kylinConfig.getKafkaConfigOverride();
+        Map<String, Object> kafkaConf = getKafkaConf(sourceProperties);
+        kafkaConf.putAll(kafkaConfigOverride);
+
+        return kafkaConf;
+        //return getKafkaConf(sourceProperties);
     }
 
     public static Map<String, Object> getKafkaConf(Map<String, String> sourceProperties) {


### PR DESCRIPTION
KafkaSource load method need kafka propeties to structure kafkaConsumer; but default code can not pass cube overwrite properties to use
like : 
kylin.source.kafka.config-override.security.protoco SASL_PLAINTEXT
kylin.source.kafka.config-override.sasl.mechanism PLAIN
kylin.source.kafka.config-override.sasl.jaas.config sasl.jaas.config
kylin.source.kafka.config-override.group.id group_id

https://issues.apache.org/jira/browse/KYLIN-3932