### PR TITLE
KYLIN-3939 add BOM character,slove the bug that it shows Chinese garb…

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -163,7 +163,13 @@ public class QueryController extends BasicController {
             // KYLIN-3939
             // Add BOM character,slove the bug that it shows Chinese garbled when using
             // excel to open scv file on windows.
-            csvWriter.write(BOM_CHARACTER);
+            // BOM character should add on head of CSV file.
+            // So add it to the head of the first index of headerList.
+            if(headerList.size()>0){
+                String tmpHeaderFirst = headerList.get(0);
+                String headerFirst = BOM_CHARACTER.concat(tmpHeaderFirst);
+                headerList.set(0, headerFirst);
+            }
 
             String[] headers = new String[headerList.size()];
             csvWriter.writeHeader(headerList.toArray(headers));

--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -154,6 +154,10 @@ public class QueryController extends BasicController {
                 headerList.add(column.getLabel());
             }
 
+            //KYLIN-3939
+            //Add BOM character,slove the bug that it shows Chinese garbled when using excel to open scv file on windows.
+            csvWriter.write(new String(new byte[] { (byte) 0xEF, (byte) 0xBB, (byte)0xBF }));
+
             String[] headers = new String[headerList.size()];
             csvWriter.writeHeader(headerList.toArray(headers));
 

--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.rest.controller;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -80,6 +81,11 @@ public class QueryController extends BasicController {
     @Autowired
     @Qualifier("queryService")
     private QueryService queryService;
+
+    private static String BOM_CHARACTER;
+    {
+        BOM_CHARACTER = new String(new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF}, StandardCharsets.UTF_8);
+    }
 
     @RequestMapping(value = "/query", method = RequestMethod.POST, produces = { "application/json" })
     @ResponseBody
@@ -154,9 +160,10 @@ public class QueryController extends BasicController {
                 headerList.add(column.getLabel());
             }
 
-            //KYLIN-3939
-            //Add BOM character,slove the bug that it shows Chinese garbled when using excel to open scv file on windows.
-            csvWriter.write(new String(new byte[] { (byte) 0xEF, (byte) 0xBB, (byte)0xBF }));
+            // KYLIN-3939
+            // Add BOM character,slove the bug that it shows Chinese garbled when using
+            // excel to open scv file on windows.
+            csvWriter.write(BOM_CHARACTER);
 
             String[] headers = new String[headerList.size()];
             csvWriter.writeHeader(headerList.toArray(headers));

--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -165,7 +165,7 @@ public class QueryController extends BasicController {
             // excel to open scv file on windows.
             // BOM character should add on head of CSV file.
             // So add it to the head of the first index of headerList.
-            if(headerList.size()>0){
+            if (headerList.size() > 0) {
                 String tmpHeaderFirst = headerList.get(0);
                 String headerFirst = BOM_CHARACTER.concat(tmpHeaderFirst);
                 headerList.set(0, headerFirst);


### PR DESCRIPTION
User can query sql in kylin portal and  then press "Export" button to download the result; the result is  csv files. User can open the csv file using excel to get the query results.
 But I find that if the result has Chinese characters, the excel will show Chinese characters garble. 

I find that if i open csv file using "notepad++", the Chinese characters are displayed normally. Then I convert this file to "UTF-8-BOM", then save this file. Then I open csv file using excel and the Chinese characters are displayed normally.
Then I add BOM identifier to the query result to be output in "QueryController.java"，I can open csv files usring excel and it displays normally. The system work fine after this change.
This commit just fix this bug.