### PR TITLE
KYLIN-3942 Support multi-level json event in backend

### DIFF
--- a/stream-source-kafka/pom.xml
+++ b/stream-source-kafka/pom.xml
@@ -61,6 +61,13 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.kylin</groupId>
+            <artifactId>kylin-core-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
 	
         <!-- Env & Test -->
 

--- a/stream-source-kafka/src/test/java/org/apache/kylin/stream/source/kafka/TimedJsonStreamParserTest.java
+++ b/stream-source-kafka/src/test/java/org/apache/kylin/stream/source/kafka/TimedJsonStreamParserTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kylin.stream.source.kafka;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kylin.common.util.LocalFileMetadataTestCase;
+import org.apache.kylin.metadata.model.TableDesc;
+import org.apache.kylin.metadata.model.TblColRef;
+import org.apache.kylin.stream.core.model.StreamingMessage;
+import org.apache.kylin.stream.core.source.MessageParserInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class TimedJsonStreamParserTest extends LocalFileMetadataTestCase {
+
+    private static String[] userNeedColNames;
+    private static ObjectMapper mapper;
+    private final JavaType mapType = MapType.construct(HashMap.class, SimpleType.construct(String.class),
+            SimpleType.construct(Object.class));
+
+    private static final String jsonFilePath = "src/test/resources/message.json";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        staticCreateTestMetadata();
+        mapper = new ObjectMapper();
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        cleanAfterClass();
+    }
+
+    @Test
+    public void testNormalValue() throws Exception {
+        userNeedColNames = new String[] { "create_at", "id", "is_truncated", "text" };
+        TimedJsonStreamParser parser = new TimedJsonStreamParser(mockupTblColRefList(), messageParserInfo());
+        Object msg = mapper.readValue(new File(jsonFilePath), mapType);
+        ByteBuffer buffer = getJsonByteBuffer(msg);
+
+        ConsumerRecord record = new ConsumerRecord<byte[], byte[]>("", 0, 0, null, buffer.array());
+        StreamingMessage parsedMsg = parser.parse(record);
+        List<String> values = parsedMsg.getData();
+        assertEquals("Jul 20, 2016 9:59:17 AM", values.get(0));
+        assertEquals("755703618762862600", values.get(1));
+        assertEquals("false", values.get(2));
+        assertEquals("dejamos", values.get(3));
+    }
+
+    @Test
+    public void testEmbeddedValue() throws Exception {
+        userNeedColNames = new String[] { "user_id", "user_description", "user_is_PROtected",
+                "user_is_Default_Profile_image", "user_type_type_name", "user_type_type1_name" };
+        List<TblColRef> allCol = mockupTblColRefList();
+        TimedJsonStreamParser parser = new TimedJsonStreamParser(allCol, messageParserInfo());
+        Object msg = mapper.readValue(new File(jsonFilePath), mapType);
+        ByteBuffer buffer = getJsonByteBuffer(msg);
+        ConsumerRecord record = new ConsumerRecord<byte[], byte[]>("", 0, 0, null, buffer.array());
+        StreamingMessage parsedMsg = parser.parse(record);
+        List<String> values = parsedMsg.getData();
+        assertNotEquals("", parsedMsg.getData().get(0));
+        assertEquals("false", values.get(2));
+        assertEquals("vip", values.get(4));
+        parsedMsg = parser.parse(record);
+        values = parsedMsg.getData();
+        assertEquals("4853763947", values.get(0));
+        assertEquals("Noticias", values.get(1));
+        assertEquals("false", values.get(2));
+        assertEquals("false", values.get(3));
+        assertEquals("vip", values.get(4));
+        assertEquals(StringUtils.EMPTY, values.get(5));
+    }
+
+    @Test
+    public void testEmbeddedValueFaultTolerant() throws Exception {
+        userNeedColNames = new String[] { "user_id", "user_sex" };
+        List<TblColRef> allCol = mockupTblColRefList();
+        TimedJsonStreamParser parser = new TimedJsonStreamParser(allCol, messageParserInfo());
+        Object msg = mapper.readValue(new File(jsonFilePath), mapType);
+        ByteBuffer buffer = getJsonByteBuffer(msg);
+        ConsumerRecord record = new ConsumerRecord<byte[], byte[]>("", 0, 0, null, buffer.array());
+        StreamingMessage parsedMsg = parser.parse(record);
+        List<String> values = parsedMsg.getData();
+        assertEquals("4853763947", values.get(0));
+        assertEquals(StringUtils.EMPTY, values.get(1));
+    }
+
+    @Test
+    public void testEmbeddedArray() throws Exception {
+        userNeedColNames = new String[] { "user_departments" };
+        List<TblColRef> allCol = mockupTblColRefList();
+        TimedJsonStreamParser parser = new TimedJsonStreamParser(allCol, messageParserInfo());
+        Object msg = mapper.readValue(new File(jsonFilePath), mapType);
+        ByteBuffer buffer = getJsonByteBuffer(msg);
+        ConsumerRecord record = new ConsumerRecord<byte[], byte[]>("", 0, 0, null, buffer.array());
+        StreamingMessage parsedMsg = parser.parse(record);
+        List<String> values = parsedMsg.getData();
+        assertEquals("[QA, RD, PM]", values.get(0));
+    }
+
+    private static MessageParserInfo messageParserInfo() {
+        MessageParserInfo parserInfo = new MessageParserInfo();
+        parserInfo.setFormatTs(false);
+        parserInfo.setTsColName("tS");
+        Map<String, String> fieldMapping = new HashMap<>();
+        fieldMapping.put("user_departments", "user.departments");
+        fieldMapping.put("user_id", "user.id");
+        fieldMapping.put("user_sex", "user.sex");
+        fieldMapping.put("user_description", "user.description");
+        fieldMapping.put("user_is_PROtected", "user.is_PROtected");
+        fieldMapping.put("user_is_Default_Profile_image", "user.is_Default_Profile_image");
+        fieldMapping.put("user_type_type_name", "user.type.type_name");
+        fieldMapping.put("user_type_type1_name", "user.type.type1_name");
+        parserInfo.setColumnToSourceFieldMapping(fieldMapping);
+        return parserInfo;
+    }
+
+    private static ByteBuffer getJsonByteBuffer(Object obj) throws IOException {
+        byte[] bytes = mapper.writeValueAsBytes(obj);
+        ByteBuffer buff = ByteBuffer.wrap(bytes);
+        buff.position(0);
+        return buff;
+    }
+
+    private static List<TblColRef> mockupTblColRefList() {
+        TableDesc t = TableDesc.mockup("table_a");
+        List<TblColRef> list = new ArrayList<>();
+        for (int i = 0; i < userNeedColNames.length; i++) {
+            TblColRef c = TblColRef.mockup(t, i, userNeedColNames[i], "string");
+            list.add(c);
+        }
+        return list;
+    }
+}

--- a/stream-source-kafka/src/test/resources/message.json
+++ b/stream-source-kafka/src/test/resources/message.json
@@ -1,0 +1,51 @@
+{
+  "create_At": "Jul 20, 2016 9:59:17 AM",
+  "id": 755703618762862600,
+  "text": "dejamos",
+  "is_truncated": false,
+  "inReplyToStatusId": -1,
+  "inReplyToUserId": -1,
+  "favoriteCount": 0,
+  "retweetCount": 0,
+  "isPossiblySensitive": false,
+  "lang": "es",
+  "contributorsIDs": [],
+  "urlEntities": [],
+  "tS": 1111112222,
+  "mediaentities": [
+    {
+      "id": 755703584084328400,
+      "sizes": {
+        "0": {
+          "width": 150,
+          "height": 150,
+          "resize": 101
+        },
+        "1": {
+          "width": 520,
+          "height": 680,
+          "resize": 100
+        }
+      },
+      "start": 48,
+      "end": 71
+    }
+  ],
+  "symbolEntities": [],
+  "currentUserRetweetId": -1,
+  "user": {
+    "id": 4853763947,
+    "description": "Noticias",
+    "is_Default_Profile_image": false,
+    "is_PROtected": false,
+    "type": {
+      "type_name": "vip",
+      "id": 1
+    },
+    "departments": [
+      "QA",
+      "RD",
+      "PM"
+    ]
+  }
+}

--- a/webapp/app/js/controllers/sourceMeta.js
+++ b/webapp/app/js/controllers/sourceMeta.js
@@ -1055,7 +1055,10 @@ KylinApp
 
         // Check template is not empty
         if (!$scope.streaming.template) {
-          $scope.tableData = undefined;
+          // $scope.tableData = undefined;
+          $scope.tableData = {
+            source_type: $scope.tableData.source_type
+          };
           $scope.streaming.errMsg = 'Please input Streaming source record to generate schema.';
           return;
         }
@@ -1064,7 +1067,9 @@ KylinApp
         try {
           var templateObj = JSON.parse($scope.streaming.template);
         } catch (error) {
-          $scope.tableData = undefined;
+          $scope.tableData = {
+            source_type: $scope.tableData.source_type
+          };
           $scope.streaming.errMsg = 'Source json invalid, Please correct your schema and generate again.';
           return;
         }
@@ -1246,7 +1251,12 @@ KylinApp
         }
         // Set ts column
         $scope.streamingConfig.parser_info.ts_col_name = $scope.streaming.TSColumnSelected;
-
+        $scope.streamingConfig.parser_info.field_mapping = {}
+        $scope.tableData.columns.forEach(function(col) {
+          if (col.comment) {
+            $scope.streamingConfig.parser_info.field_mapping[col.name] = col.comment.replace(/\|/g, '.') || ''
+          }
+        })
         SweetAlert.swal({
           title: '',
           text: 'Are you sure to save the streaming table?',


### PR DESCRIPTION
# Problem
Currently real-time OLAP didn't support  multi-level json event.
For example,if I have a kafka multi-level json event like this:

### Sample Event
```json
{"country":"JAPAN","amount":13.075058425023922,"qty":8,"currency":"USD","order_time":1554801950882,"category":"ELECTRONIC","device":"Andriod","user":{"gender":"Female","id":"7a0cfa5e-bbaa-79ef-1a38-e06f02c85fcb","first_name":"unknown","age":16}}
```


### streaming_receiver.log
```
2019-04-09 09:46:09,878 ERROR [StreamingV2Cube_channel] kafka.TimedJsonStreamParser:107 : error
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token
at [Source: (String)"\{"country":"US","amount":14.498498222823619,"qty":1,"currency":"USD","order_time":1554803169876,"category":"Other","device":"Other","user":{"gender":"Female","id":"0736b41a-9ae7-9b4a-a124-f74436d3eb41","first_name":"unknown","age":26}}"; line: 1, column: 140] (through reference chain: java.util.HashMap["user"])
at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63)
at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1342)
at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1138)
at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1092)
at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:63)
at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:10)
at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:527)
at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:364)
at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:29)
at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4001)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3030)
at org.apache.kylin.stream.source.kafka.TimedJsonStreamParser.parse(TimedJsonStreamParser.java:79)
at org.apache.kylin.stream.source.kafka.TimedJsonStreamParser.parse(TimedJsonStreamParser.java:54)
at org.apache.kylin.stream.source.kafka.consumer.KafkaConnector.nextEvent(KafkaConnector.java:110)
at org.apache.kylin.stream.core.consumer.StreamingConsumerChannel.run(StreamingConsumerChannel.java:93)
at java.lang.Thread.run(Thread.java:748)
```

# After repair

```json
{"act_type": "play", "uid": 1716, "video_id": 1786, "play_duration": 10.2966, "detail": {"Info": "dk", "Type": "abc", "location": {"province": "taiwan"}}, "video_type": "3aa17", "ts": 1555261235000, "pageview_id": "6ed3aa34d75f0", "play_times": 31}
```

<img width="1407" alt="image" src="https://user-images.githubusercontent.com/14030549/56103940-e634c900-5f67-11e9-9253-0216f59c5481.png">

<img width="1402" alt="d97bdc4e-5952-4383-a1f8-eefc06933a03" src="https://user-images.githubusercontent.com/14030549/56103945-f3ea4e80-5f67-11e9-851a-da928d26b857.png">