### PR TITLE
KYLIN-3957 Fix exception cannot cast 'java.math.BigDecimal' to 'java.…

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/metadata/model/FunctionDesc.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/model/FunctionDesc.java
@@ -167,7 +167,15 @@ public class FunctionDesc implements Serializable {
             if (isMax() || isMin()) {
                 return parameter.getColRefs().get(0).getType();
             } else if (isSum()) {
-                return parameter.isColumnType() ? DataType.getType(returnType) : DataType.getType("bigint");
+                if (parameter.isColumnType()) {
+                    if (parameter.getColRefs().get(0).getType().isIntegerFamily()) {
+                        return DataType.getType("bigint");
+                    } else {
+                        return parameter.getColRefs().get(0).getType();
+                    }
+                } else {
+                    return DataType.getType("bigint");
+                }
             } else if (isCount()) {
                 return DataType.getType("bigint");
             } else {

--- a/core-metadata/src/test/java/org/apache/kylin/metadata/model/FunctionDescTest.java
+++ b/core-metadata/src/test/java/org/apache/kylin/metadata/model/FunctionDescTest.java
@@ -37,6 +37,7 @@ public class FunctionDescTest {
     public void getRewriteFieldType() {
         TblColRef mockColOfDoubleType = TblColRef.mockup(TableDesc.mockup("mock_table"), 0, "price", "double", "");
         TblColRef mockColOfDecimalType = TblColRef.mockup(TableDesc.mockup("mock_table"), 1, "price", "decimal", "");
+        TblColRef mockColOfIntegerType = TblColRef.mockup(TableDesc.mockup("mock_table"), 2, "price", "integer", "");
 
         FunctionDesc function = FunctionDesc.newInstance("SUM", ParameterDesc.newInstance("1"), "bigint");
         assertEquals(DataType.getType("bigint"), function.getRewriteFieldType());
@@ -44,6 +45,8 @@ public class FunctionDescTest {
         assertEquals(DataType.getType("bigint"), function.getRewriteFieldType());
         function = FunctionDesc.newInstance("SUM", ParameterDesc.newInstance(mockColOfDoubleType), "double");
         assertEquals(DataType.getType("double"), function.getRewriteFieldType());
+        function = FunctionDesc.newInstance("SUM", ParameterDesc.newInstance(mockColOfIntegerType), "bigint");
+        assertEquals(DataType.getType("bigint"), function.getRewriteFieldType());
         function = FunctionDesc.newInstance("MAX", ParameterDesc.newInstance(mockColOfDecimalType), "double");
         assertEquals(DataType.getType("decimal"), function.getRewriteFieldType());
         function = FunctionDesc.newInstance("MIN", ParameterDesc.newInstance(mockColOfDecimalType), "double");


### PR DESCRIPTION
…lang.Double'