### PR TITLE
KYLIN-3961 Optimize TopNCounter's merge function to reduce TopNCounter's error size.

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/measure/topn/TopNCounter.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/topn/TopNCounter.java
@@ -155,25 +155,12 @@ public class TopNCounter<T> implements Iterable<Counter<T>>, java.io.Serializabl
      * @return
      */
     public TopNCounter<T> merge(TopNCounter<T> another) {
-        boolean thisFull = this.size() >= this.capacity;
-        boolean anotherFull = another.size() >= another.capacity;
-        double m1 = thisFull ? this.counterList.getLast().count : 0.0;
-        double m2 = anotherFull ? another.counterList.getLast().count : 0.0;
-
-        if (anotherFull == true) {
-            for (Counter<T> entry : this.counterMap.values()) {
-                entry.count += m2;
-            }
-        }
-
         for (Map.Entry<T, Counter<T>> entry : another.counterMap.entrySet()) {
             Counter<T> counter = this.counterMap.get(entry.getKey());
             if (counter != null) {
-                //                this.offer(entry.getValue().getItem(), (entry.getValue().count - m2));
-                counter.setCount(counter.getCount() + (entry.getValue().count - m2));
+                counter.setCount(counter.getCount() + entry.getValue().count);
             } else {
-                //                this.offer(entry.getValue().getItem(), entry.getValue().count + m1);
-                counter = new Counter<T>(entry.getValue().getItem(), entry.getValue().count + m1);
+                counter = new Counter<T>(entry.getValue().getItem(), entry.getValue().count);
                 this.counterMap.put(entry.getValue().getItem(), counter);
                 this.counterList.add(counter);
             }

--- a/core-metadata/src/test/java/org/apache/kylin/measure/topn/TopNCounterBasicTest.java
+++ b/core-metadata/src/test/java/org/apache/kylin/measure/topn/TopNCounterBasicTest.java
@@ -130,4 +130,33 @@ public class TopNCounterBasicTest {
         }
 
     }
+
+    @Test
+    public void testMerge2() {
+
+        TopNCounter<String> vs = new TopNCounter<String>(3);
+        String[] stream = { "AA", "BB", "CC", "AA", "BB", "CC", "DD", "DD" };
+        for (String i : stream) {
+            vs.offer(i);
+        }
+
+        String[] stream2 = { "AA", "BB", "CC", "AA", "BB", "CC" };
+        TopNCounter<String> vs2 = new TopNCounter<String>(3);
+        for (String i : stream2) {
+            vs2.offer(i);
+        }
+        vs.merge(vs2);
+
+        String[] stream3 = { "AA", "BB", "CC", "DD", "DD", "DD" };
+        TopNCounter<String> vs3 = new TopNCounter<String>(3);
+        for (String i : stream3) {
+            vs3.offer(i);
+        }
+
+        vs.merge(vs3);
+
+        List<Counter<String>> topK = vs.topK(1);
+        assertTrue(topK.get(0).getItem().equals("DD"));
+
+    }
 }


### PR DESCRIPTION
Sometimes TopN measure query will return a large error.
I optimize TopNCounter's merge function to reduce TopNCounter's errors when using TopN measure.
This optimization work well in my kylin system and reduce TopNCounter's error size.