### PR TITLE
Fixed use customized precision

### DIFF
--- a/webapp/app/js/controllers/cubeMeasures.js
+++ b/webapp/app/js/controllers/cubeMeasures.js
@@ -462,7 +462,7 @@ KylinApp.controller('CubeMeasuresCtrl', function ($scope, $modal,MetaModel,cubes
          if(colType.indexOf('decimal') != -1) {
             var returnRegex = new RegExp('(\\w+)(?:\\((\\w+?)(?:\\,(\\w+?))?\\))?');
             var returnValue = returnRegex.exec(colType);
-            var precision = 19;
+            var precision = returnValue[2] || 0;
             var scale = returnValue[3] || 0;
             return 'decimal(' + precision + ',' + scale + ')';
           }else{


### PR DESCRIPTION
In the cubeMeasures.js, It will withdraw precision and scale by using Regular Expression. The scale parameter is ok, but precision use the magic number 19. 
So we fixed it, and we test ok when the column is decimal(38,18).