### PR TITLE
KYLIN-3969 Fix Beeline meta data parser on partition information

### DIFF
--- a/source-hive/src/main/java/org/apache/kylin/source/hive/BeelineHiveClient.java
+++ b/source-hive/src/main/java/org/apache/kylin/source/hive/BeelineHiveClient.java
@@ -203,14 +203,15 @@ public class BeelineHiveClient implements IHiveClient {
             resultSet.next();
             Preconditions.checkArgument("# col_name".equals(resultSet.getString(1).trim()));
             resultSet.next();
-            Preconditions.checkArgument("".equals(resultSet.getString(1).trim()));
-            while (resultSet.next()) {
-                if ("".equals(resultSet.getString(1).trim())) {
-                    break;
-                }
-                partitionColumns.add(new HiveTableMeta.HiveTableColumnMeta(resultSet.getString(1).trim(),
-                        resultSet.getString(2).trim(), resultSet.getString(3).trim()));
-            }
+            if ("".equals(resultSet.getString(1).trim()))
+                resultSet.next();
+            do {
+                 if ("".equals(resultSet.getString(1).trim())) {
+                     break;
+                 }
+                 partitionColumns.add(new HiveTableMeta.HiveTableColumnMeta(resultSet.getString(1).trim(),
+                         resultSet.getString(2).trim(), resultSet.getString(3).trim()));
+            } while (resultSet.next());
             builder.setPartitionColumns(partitionColumns);
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KYLIN-3969

In CLI + Hive2, "desc formatted tablename" outputs following text at "Partition Information" section:
```
# Partition Information
# col_name data_type comment

pt string
```
And the code checks if the blank line exists.

But with Beeline client and Hive 3, the output becomes: 
```
| # Partition Information       | NULL                                               | NULL                  |
| # col_name                    | data_type                                          | comment               |
| pt                            | string                                             |                       |
```

The blank line is gone, which causes problem when user trying to load table.