### PR TITLE
KYLIN-4001 Allow user-specified time format using real-time

### DIFF
--- a/stream-core/src/main/java/org/apache/kylin/stream/core/source/MessageParserInfo.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/source/MessageParserInfo.java
@@ -28,6 +28,12 @@ public class MessageParserInfo {
     @JsonProperty("ts_col_name")
     private String tsColName;
 
+    @JsonProperty("ts_parser")
+    private String tsParser;
+
+    @JsonProperty("ts_pattern")
+    private String tsPattern;
+
     @JsonProperty("format_ts")
     private boolean formatTs;
 
@@ -40,6 +46,22 @@ public class MessageParserInfo {
 
     public void setTsColName(String tsColName) {
         this.tsColName = tsColName;
+    }
+
+    public String getTsParser() {
+        return tsParser;
+    }
+
+    public void setTsParser(String tsParser) {
+        this.tsParser = tsParser;
+    }
+
+    public String getTsPattern() {
+        return tsPattern;
+    }
+
+    public void setTsPattern(String tsPattern) {
+        this.tsPattern = tsPattern;
     }
 
     public boolean isFormatTs() {

--- a/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/AbstractTimeParser.java
+++ b/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/AbstractTimeParser.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.apache.kylin.stream.source.kafka;
+
+import org.apache.kylin.stream.core.source.MessageParserInfo;
+
+
+/**
+ * Created by guoning on 2019-04-29.
+ */
+public abstract class AbstractTimeParser {
+
+    public AbstractTimeParser(MessageParserInfo parserInfo) {
+    }
+
+    /**
+     * Parse a string time to a long value (epoch time)
+     * @param time
+     * @return
+     */
+    abstract public long parseTime(String time) throws IllegalArgumentException;
+}

--- a/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/DateTimeParser.java
+++ b/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/DateTimeParser.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.kylin.stream.source.kafka;
+
+import org.apache.commons.lang3.time.FastDateFormat;
+import org.apache.kylin.stream.core.source.MessageParserInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by guoning on 2019-04-29.
+ */
+public class DateTimeParser extends AbstractTimeParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(DateTimeParser.class);
+    private String tsPattern  = null;
+    private FastDateFormat formatter = null;
+
+
+    public DateTimeParser(MessageParserInfo parserInfo) {
+        super(parserInfo);
+        tsPattern = parserInfo.getTsPattern();
+        try {
+            formatter = org.apache.kylin.common.util.DateFormat.getDateFormat(tsPattern);
+        } catch (Throwable e) {
+            throw new IllegalStateException("Invalid tsPattern: '" + tsPattern + "'.");
+        }
+    }
+
+    @Override
+    public long parseTime(String timeStr) throws IllegalArgumentException {
+        try {
+            return formatter.parse(timeStr).getTime();
+        } catch (Throwable e) {
+            throw new IllegalArgumentException("Invalid value: pattern: '" + tsPattern + "', value: '" + timeStr + "'", e);
+        }
+    }
+}

--- a/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/LongTimeParser.java
+++ b/stream-source-kafka/src/main/java/org/apache/kylin/stream/source/kafka/LongTimeParser.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.stream.source.kafka;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kylin.stream.core.source.MessageParserInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+/**
+ * Created by guoning on 2019-04-29.
+ */
+public class LongTimeParser extends AbstractTimeParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(LongTimeParser.class);
+    private String tsPattern = null;
+
+    public LongTimeParser(MessageParserInfo parserInfo) {
+        super(parserInfo);
+        tsPattern = parserInfo.getTsPattern().toUpperCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Parse a string time to a long value (epoch time)
+     *
+     * @param time
+     * @return
+     */
+    public long parseTime(String time) throws IllegalArgumentException {
+        long t;
+        if (StringUtils.isEmpty(time)) {
+            t = 0;
+        } else {
+            try {
+                t = Long.parseLong(time);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+        if ("S".equals(tsPattern)) {
+            t = t * 1000;
+        }
+        return t;
+    }
+}

--- a/webapp/app/js/controllers/sourceMeta.js
+++ b/webapp/app/js/controllers/sourceMeta.js
@@ -965,6 +965,8 @@ KylinApp
             dataTypeArr: tableConfig.dataTypes,
             TSColumnArr: [],
             TSColumnSelected: '',
+            TSParser: 'org.apache.kylin.stream.source.kafka.LongTimeParser',
+            TSPattern: 'MS',
             errMsg: ''
           };
           $scope.tableData = {
@@ -1020,6 +1022,8 @@ KylinApp
         dataTypeArr: tableConfig.dataTypes,
         TSColumnArr: [],
         TSColumnSelected: '',
+        TSParser: '',
+        TSPattern: '',
         errMsg: '',
         lambda: false
       };
@@ -1251,7 +1255,9 @@ KylinApp
         }
         // Set ts column
         $scope.streamingConfig.parser_info.ts_col_name = $scope.streaming.TSColumnSelected;
-        $scope.streamingConfig.parser_info.field_mapping = {}
+        $scope.streamingConfig.parser_info.ts_parser = $scope.streaming.TSParser;
+        $scope.streamingConfig.parser_info.ts_pattern = $scope.streaming.TSPattern;
+        $scope.streamingConfig.parser_info.field_mapping = {};
         $scope.tableData.columns.forEach(function(col) {
           if (col.comment) {
             $scope.streamingConfig.parser_info.field_mapping[col.name] = col.comment.replace(/\|/g, '.') || ''

--- a/webapp/app/partials/tables/loadStreamingTableConfig.html
+++ b/webapp/app/partials/tables/loadStreamingTableConfig.html
@@ -70,7 +70,19 @@
         <div class="form-group required">
           <label for="TSColumn" class="col-sm-3 control-label font-color-default">TSColumn</label>
           <div class="col-sm-6">
-            <select chosen ng-model="streaming.TSColumnSelected" ng-options="TSColumn as TSColumn for TSColumn in streaming.TSColumnArr" data-placeholder="select a column name" style="width: 120px !important;" class="chosen-select" ng-change="updateTSColumn(TSColumn)"></select>
+            <select id="TSColumn" chosen ng-model="streaming.TSColumnSelected" ng-options="TSColumn as TSColumn for TSColumn in streaming.TSColumnArr" data-placeholder="select a column name" style="width: 120px !important;" class="chosen-select" ng-change="updateTSColumn(TSColumn)"></select>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="TSParser" class="col-sm-3 control-label font-color-default">TSParser</label>
+          <div class="col-sm-9">
+            <input type="text" class="form-control" id="TSParser" ng-model="streaming.TSParser" name="TSParser" placeholder="Input TSParser eg org.apache.kylin.stream.source.kafka.TimedJsonStreamParser" required>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="TSPattern" class="col-sm-3 control-label font-color-default">TSPattern</label>
+          <div class="col-sm-9">
+            <input type="text" class="form-control" id="TSPattern" ng-model="streaming.TSPattern" name="TSPattern" placeholder="Input TSPattern eg. yyyy-MM-dd HH:mm:ss">
           </div>
         </div>
 

--- a/webapp/app/partials/tables/table_detail.html
+++ b/webapp/app/partials/tables/table_detail.html
@@ -196,6 +196,14 @@
                   </th>
                   <td>{{currentStreamingConfig.properties['bootstrap.servers']}}</td>
                 </tr>
+                <tr>
+                  <th>TSParse</th>
+                  <td>{{currentStreamingConfig.parser_info.ts_parser}}</td>
+                </tr>
+                <tr>
+                  <th>TSPattern</th>
+                  <td>{{currentStreamingConfig.parser_info.ts_pattern}}</td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
**Allow user-specified time format using real-time**

I found that real-time only supports millisecond timestamp, does not support second timestamp and  Date type like '2019-01-01 11:11:11'.
I add a LongTimeParser and a DateTimeParser and page configuration 
You can configure tsParser, tsPattern on the page that creates the streaming table.

- for date :
`{ "timestamp":"2019-04-29 11:11:11","gmv":1.1 }`
 `tsParser=org.apache.kylin.stream.source.kafka.DateTimeParser`
 `tsPattern=yyyy-MM-dd HH:mm:ss`

- for second  : 
`{ "timestamp":"1556618887","gmv":1.1 }`
`tsParser=org.apache.kylin.stream.source.kafka.LongTimeParser`
`tsPattern=S`

- for millisecond : 
`{ "timestamp":"1556618887000","gmv":1.1 }`
`tsParser=org.apache.kylin.stream.source.kafka.LongTimeParser`
`tsPattern=MS`
