### PR TITLE
KYLIN-3994: StorageCleanupJob may delete cube id data of new built segment because of cube cache in CubeManager

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/job/MetadataCleanupJob.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/MetadataCleanupJob.java
@@ -73,7 +73,6 @@ public class MetadataCleanupJob {
 
     // function entrance
     public List<String> cleanup(boolean delete, int jobOutdatedDays) throws Exception {
-        CubeManager cubeManager = CubeManager.getInstance(config);
         ResourceStore store = ResourceStore.getStore(config);
         long newResourceTimeCut = System.currentTimeMillis() - NEW_RESOURCE_THREADSHOLD_MS;
         FileSystem fs = HadoopUtil.getWorkingFileSystem(HadoopUtil.getCurrentConfiguration());
@@ -122,6 +121,8 @@ public class MetadataCleanupJob {
 
         // exclude resources in use
         Set<String> activeResources = Sets.newHashSet();
+        // CubeManager need be inited after listing resources to be deleted
+        CubeManager cubeManager = CubeManager.getInstance(config);
         for (CubeInstance cube : cubeManager.listAllCubes()) {
             activeResources.addAll(cube.getSnapshots().values());
             for (CubeSegment segment : cube.getSegments()) {

--- a/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtil.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtil.java
@@ -56,8 +56,6 @@ public class StorageCleanJobHbaseUtil {
 
     static List<String> cleanUnusedHBaseTables(HBaseAdmin hbaseAdmin, boolean delete, int deleteTimeout) throws IOException {
         KylinConfig config = KylinConfig.getInstanceFromEnv();
-        CubeManager cubeMgr = CubeManager.getInstance(config);
-        
         // get all kylin hbase tables
         String namespace = config.getHBaseStorageNameSpace();
         String tableNamePrefix = (namespace.equals("default") || namespace.equals(""))
@@ -80,6 +78,8 @@ public class StorageCleanJobHbaseUtil {
             }
         }
 
+        // CubeManager need be inited after listing hbase tabales to be deleted
+        CubeManager cubeMgr = CubeManager.getInstance(config);
         // remove every segment htable from drop list
         for (CubeInstance cube : cubeMgr.listAllCubes()) {
             for (CubeSegment seg : cube.getSegments()) {

--- a/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanupJob.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanupJob.java
@@ -224,8 +224,6 @@ public class StorageCleanupJob extends AbstractApplication {
     
     private void cleanUnusedHdfsFiles(FileSystem fs, UnusedHdfsFileCollector collector) throws IOException {
         final JobEngineConfig engineConfig = new JobEngineConfig(config);
-        final CubeManager cubeMgr = CubeManager.getInstance(config);
-        
         List<String> allHdfsPathsNeedToBeDeleted = new ArrayList<String>();
         
         try {
@@ -254,7 +252,8 @@ public class StorageCleanupJob extends AbstractApplication {
                         + " with status " + state);
             }
         }
-
+        // CubeManager need be inited after listing hdfs path to be deleted
+        final CubeManager cubeMgr = CubeManager.getInstance(config);
         // remove every segment working dir from deletion list
         for (CubeInstance cube : cubeMgr.listAllCubes()) {
             for (CubeSegment seg : cube.getSegments()) {


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3994