### PR TITLE
KYLIN-3994: StorageCleanupJob may delete cube id data of new built segment because of cube cache in CubeManager

### DIFF
--- a/core-cube/src/main/java/org/apache/kylin/cube/CubeManager.java
+++ b/core-cube/src/main/java/org/apache/kylin/cube/CubeManager.java
@@ -182,14 +182,25 @@ public class CubeManager implements IRealizationProvider {
         }
     }
 
+    /**
+     * List all cubes from cache. Note the metadata may be out of date
+     * @return
+     */
     public List<CubeInstance> listAllCubes() {
         try (AutoLock lock = cubeMapLock.lockForRead()) {
             return new ArrayList<CubeInstance>(cubeMap.values());
         }
     }
 
+    /**
+     * Reload the cubes from database and list all cubes
+     * @return
+     * @throws IOException
+     */
     public List<CubeInstance> reloadAndListAllCubes() throws IOException {
-        crud.reloadAll();
+        try (AutoLock lock = cubeMapLock.lockForWrite()) {
+            crud.reloadAll();
+        }
         return listAllCubes();
     }
 

--- a/core-cube/src/main/java/org/apache/kylin/cube/CubeManager.java
+++ b/core-cube/src/main/java/org/apache/kylin/cube/CubeManager.java
@@ -188,6 +188,11 @@ public class CubeManager implements IRealizationProvider {
         }
     }
 
+    public List<CubeInstance> reloadAndListAllCubes() throws IOException {
+        crud.reloadAll();
+        return listAllCubes();
+    }
+
     public CubeInstance getCube(String cubeName) {
         try (AutoLock lock = cubeMapLock.lockForRead()) {
             return cubeMap.get(cubeName);

--- a/server-base/src/main/java/org/apache/kylin/rest/job/MetadataCleanupJob.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/MetadataCleanupJob.java
@@ -132,7 +132,7 @@ public class MetadataCleanupJob {
 
         // exclude resources in use
         Set<String> activeResources = Sets.newHashSet();
-        for (CubeInstance cube : cubeManager.listAllCubes()) {
+        for (CubeInstance cube : cubeManager.reloadAndListAllCubes()) {
             activeResources.addAll(cube.getSnapshots().values());
             for (CubeSegment segment : cube.getSegments()) {
                 activeResources.addAll(segment.getSnapshotPaths());

--- a/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtil.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtil.java
@@ -81,7 +81,7 @@ public class StorageCleanJobHbaseUtil {
         }
 
         // remove every segment htable from drop list
-        for (CubeInstance cube : cubeMgr.listAllCubes()) {
+        for (CubeInstance cube : cubeMgr.reloadAndListAllCubes()) {
             for (CubeSegment seg : cube.getSegments()) {
                 String tablename = seg.getStorageLocationIdentifier();
                 if (allTablesNeedToBeDropped.contains(tablename)) {

--- a/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanupJob.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanupJob.java
@@ -256,7 +256,7 @@ public class StorageCleanupJob extends AbstractApplication {
         }
 
         // remove every segment working dir from deletion list
-        for (CubeInstance cube : cubeMgr.listAllCubes()) {
+        for (CubeInstance cube : cubeMgr.reloadAndListAllCubes()) {
             for (CubeSegment seg : cube.getSegments()) {
                 String jobUuid = seg.getLastBuildJobID();
                 if (jobUuid != null && jobUuid.equals("") == false) {


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3994