### PR TITLE
adjust HBase tableName toUpperCase for HFile

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
@@ -51,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import static org.apache.hadoop.hbase.HBaseConfiguration.merge;
 
@@ -101,7 +100,7 @@ public class CubeHFileJob extends AbstractHadoopJob {
 
             Configuration hbaseConf = HBaseConfiguration.create(getConf());
 
-            String hTableName = getOptionValue(OPTION_HTABLE_NAME).toUpperCase(Locale.ROOT);
+            String hTableName = getOptionValue(OPTION_HTABLE_NAME);
             connection = ConnectionFactory.createConnection(hbaseConf);
             Table table = connection.getTable(TableName.valueOf(hTableName));
             RegionLocator regionLocator = connection.getRegionLocator(TableName.valueOf(hTableName));


### PR DESCRIPTION
### Description
HBase is case sensitive, tableName.toUpperCase() will lead to the created table can not be found.

### Improvement
Just remove the toUppderCase() in CubeHFileJob.
