### PR TITLE
KYLIN-4017 Build engine get zk(zookeeper) lock failed when building job, it causes the whole build engine doesn't work

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/ZKUtil.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/ZKUtil.java
@@ -84,7 +84,7 @@ public class ZKUtil {
                         logger.error("Error at closing " + curator, ex);
                     }
                 }
-            }).expireAfterWrite(1, TimeUnit.DAYS).build();
+            }).expireAfterWrite(10000, TimeUnit.DAYS).build();//never expired
 
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {


### PR DESCRIPTION
```
【Type】：BUG 
【Severity】：1-Blocker
【Module】：Build Engine
【Description】：Kylin build engine occasionally appears to be unable to get the ZK lock exception, and once this build engine appears, it will not work and can only be restarted to solve.Usually this problem will recur one day after the build engine starts.
【Design】：Setting the cache for curator is never invalid (unless the service stops) and check the state before use curator instance (if closed ,create a new curator instance and put into the cache)
```
```
issue: https://issues.apache.org/jira/browse/KYLIN-4017
```