### PR TITLE
KYLIN-4022 when Adhoc Push Down then Unrecognized column type: DECIMA…

### DIFF
--- a/query/src/main/java/org/apache/kylin/query/adhoc/PushDownRunnerJdbcImpl.java
+++ b/query/src/main/java/org/apache/kylin/query/adhoc/PushDownRunnerJdbcImpl.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 public class PushDownRunnerJdbcImpl extends AbstractPushdownRunner {
 
@@ -246,7 +247,7 @@ public class PushDownRunnerJdbcImpl extends AbstractPushdownRunner {
             return Types.DATE;
         } else if ("timestamp".equalsIgnoreCase(type)) {
             return Types.TIMESTAMP;
-        } else if ("decimal".equalsIgnoreCase(type)) {
+        } else if (type.toLowerCase(Locale.ROOT).startsWith("decimal")) {
             return Types.DECIMAL;
         } else if ("binary".equalsIgnoreCase(type)) {
             return Types.BINARY;


### PR DESCRIPTION
when query like select dnum from table and dnum is DECIMAL(38,6) then throw

ERROR [Query 0e816abd-28cc-4f6e-9116-f1349c1f1b39-72] service.QueryService:1001 : pushdown engine failed current query too
java.sql.SQLException: Unrecognized column type: DECIMAL(38,6)
at org.apache.kylin.query.adhoc.PushDownRunnerJdbcImpl.toSqlType(PushDownRunnerJdbcImpl.java:263)
at org.apache.kylin.query.adhoc.PushDownRunnerJdbcImpl.extractColumnMeta(PushDownRunnerJdbcImpl.java:195)
at org.apache.kylin.query.adhoc.PushDownRunnerJdbcImpl.executeQuery(PushDownRunnerJdbcImpl.java:71)
at org.apache.kylin.query.util.PushDownUtil.tryPushDownQuery(PushDownUtil.java:122)
at org.apache.kylin.query.util.PushDownUtil.tryPushDownSelectQuery(PushDownUtil.java:69)
at org.apache.kylin.rest.service.QueryService.pushDownQuery(QueryService.java:998)
at org.apache.kylin.rest.service.QueryService.executeRequest(QueryService.java:954)
at org.apache.kylin.rest.service.QueryService.queryWithSqlMassage(QueryService.java:652)
at org.apache.kylin.rest.service.QueryService.query(QueryService.java:212)
at org.apache.kylin.rest.service.QueryService.queryAndUpdateCache(QueryService.java:479)
at org.apache.kylin.rest.service.QueryService.doQueryWithCache(QueryService.java:440)
at org.apache.kylin.rest.service.QueryService.doQueryWithCache(QueryService.java:373)
at org.apache.kylin.rest.controller.QueryController.query(QueryController.java:87)