### PR TITLE
#KYLIN-4030, ResourceStore deleteResource by comparing timestamp may be failed

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/persistence/FileResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/FileResourceStore.java
@@ -208,8 +208,12 @@ public class FileResourceStore extends ResourceStore {
         try {
             if (f.exists()) {
                 long origLastModified = getResourceTimestampImpl(resPath);
-                if (checkTimeStampBeforeDelete(origLastModified, timestamp))
+                if (checkTimeStampBeforeDelete(origLastModified, timestamp)) {
                     FileUtils.forceDelete(f);
+                } else {
+                    throw new IOException("Resource " + resPath + " timestamp not match, [originLastModified: "
+                            + origLastModified + ", timestampToDelete: " + timestamp + "]");
+                }
             }
         } catch (FileNotFoundException e) {
             // FileNotFoundException is not a problem in case of delete

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/HDFSResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/HDFSResourceStore.java
@@ -277,8 +277,13 @@ public class HDFSResourceStore extends ResourceStore {
             Path p = getRealHDFSPath(resPath);
             if (fs.exists(p)) {
                 long origLastModified = fs.getFileStatus(p).getModificationTime();
-                if (checkTimeStampBeforeDelete(origLastModified, timestamp))
+                if (checkTimeStampBeforeDelete(origLastModified, timestamp)) {
                     fs.delete(p, true);
+                } else {
+                    throw new IOException("Resource " + resPath + " timestamp not match, [originLastModified: "
+                            + origLastModified + ", timestampToDelete: " + timestamp + "]");
+                }
+
             }
         } catch (Exception e) {
             throw new IOException("Delete resource fail", e);

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/JDBCResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/JDBCResourceStore.java
@@ -573,8 +573,12 @@ public class JDBCResourceStore extends PushdownResourceStore {
     protected void deleteResourceImpl(String resPath, long timestamp) throws IOException {
         // considering deletePushDown operation, check timestamp at the beginning
         long origLastModified = getResourceTimestampImpl(resPath);
-        if (checkTimeStampBeforeDelete(origLastModified, timestamp))
+        if (checkTimeStampBeforeDelete(origLastModified, timestamp)) {
             deleteResourceImpl(resPath);
+        } else {
+            throw new IOException("Resource " + resPath + " timestamp not match, [originLastModified: "
+                    + origLastModified + ", timestampToDelete: " + timestamp + "]");
+        }
     }
 
     @Override

--- a/core-common/src/test/java/org/apache/kylin/common/persistence/ResourceStoreTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/persistence/ResourceStoreTest.java
@@ -208,10 +208,14 @@ public class ResourceStoreTest {
         assertTrue(list == null || !list.contains(path2));
 
         long origLastModified = store.getResourceTimestamp(path3);
-        long beforeLastModified = origLastModified - 100;
+        long beforeLastModified = origLastModified - 1000;
 
         //  beforeLastModified < origLastModified  ==> not delete expected
-        store.deleteResource(path3, beforeLastModified);
+        try {
+            store.deleteResource(path3, beforeLastModified);
+        } catch (Exception e) {
+            assertTrue(e instanceof IOException);
+        }
         assertTrue(store.exists(path3));
         list = store.listResources(dir3);
         assertTrue(list != null && list.contains(path3));
@@ -230,7 +234,7 @@ public class ResourceStoreTest {
         assertEquals(content3, t);
 
         origLastModified = store.getResourceTimestamp(path3);
-        long afterLastModified = origLastModified + 100;
+        long afterLastModified = origLastModified + 1000;
 
         // afterLastModified > origLastModified ==> delete expected
         store.deleteResource(path3, afterLastModified);

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/HBaseResourceStore.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/HBaseResourceStore.java
@@ -411,7 +411,11 @@ public class HBaseResourceStore extends PushdownResourceStore {
                 if (hdfsResourceExist) { // remove hdfs cell value
                     deletePushdown(resPath);
                 }
+            } else {
+                throw new IOException("Resource " + resPath + " timestamp not match, [originLastModified: "
+                        + origLastModified + ", timestampToDelete: " + timestamp + "]");
             }
+
         } finally {
             IOUtils.closeQuietly(table);
         }


### PR DESCRIPTION
See #KYLIN-4030