### PR TITLE
remove tableName.toUppderCase() for hbase table Name,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
     - $HOME/.m2
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_script:
   - echo "MAVEN_OPTS='-Xms1024m -Xmx3072m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m'" > ~/.mavenrc

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
@@ -51,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import static org.apache.hadoop.hbase.HBaseConfiguration.merge;
 
@@ -101,7 +100,7 @@ public class CubeHFileJob extends AbstractHadoopJob {
 
             Configuration hbaseConf = HBaseConfiguration.create(getConf());
 
-            String hTableName = getOptionValue(OPTION_HTABLE_NAME).toUpperCase(Locale.ROOT);
+            String hTableName = getOptionValue(OPTION_HTABLE_NAME);
             connection = ConnectionFactory.createConnection(hbaseConf);
             Table table = connection.getTable(TableName.valueOf(hTableName));
             RegionLocator regionLocator = connection.getRegionLocator(TableName.valueOf(hTableName));


### PR DESCRIPTION
**Description**
HBase is case sensitive，tableName.toUpperCase() will lead to the created table could not be found.
If my tableName of HBase is lowercase, kylin can't find the table created in the HFile generated step.

**Improvement**
just remove toUpperCase() for HBase tableName on master-hadoop3.1.