### PR TITLE
KYLIN-4047 Use push-down query when division dynamic column cube query is not supported

### DIFF
--- a/core-metadata/src/main/java/org/apache/kylin/exception/QueryOnCubeException.java
+++ b/core-metadata/src/main/java/org/apache/kylin/exception/QueryOnCubeException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.apache.kylin.exception;
+
+/**
+ *
+ */
+public class QueryOnCubeException extends RuntimeException{
+
+    public QueryOnCubeException() {
+        super();
+    }
+
+
+    public QueryOnCubeException(String s) {
+        super(s);
+    }
+
+    public QueryOnCubeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+
+    public QueryOnCubeException(Throwable cause) {
+        super(cause);
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/core-metadata/src/main/java/org/apache/kylin/exception/QueryOnCubeException.java
+++ b/core-metadata/src/main/java/org/apache/kylin/exception/QueryOnCubeException.java
@@ -21,12 +21,13 @@ package org.apache.kylin.exception;
 /**
  *
  */
-public class QueryOnCubeException extends RuntimeException{
+public class QueryOnCubeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
 
     public QueryOnCubeException() {
         super();
     }
-
 
     public QueryOnCubeException(String s) {
         super(s);
@@ -36,10 +37,7 @@ public class QueryOnCubeException extends RuntimeException{
         super(message, cause);
     }
 
-
     public QueryOnCubeException(Throwable cause) {
         super(cause);
     }
-
-    private static final long serialVersionUID = 1L;
 }

--- a/core-metadata/src/main/java/org/apache/kylin/metadata/expression/BinaryTupleExpression.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/expression/BinaryTupleExpression.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.kylin.common.util.DecimalUtil;
+import org.apache.kylin.exception.QueryOnCubeException;
 import org.apache.kylin.metadata.filter.IFilterCodeSystem;
 import org.apache.kylin.metadata.tuple.IEvaluatableTuple;
 
@@ -64,7 +65,7 @@ public class BinaryTupleExpression extends TupleExpression {
     private void verifyMultiply() {
         if (ExpressionColCollector.collectMeasureColumns(getLeft()).size() > 0 //
                 && ExpressionColCollector.collectMeasureColumns(getRight()).size() > 0) {
-            throw new IllegalArgumentException(
+            throw new QueryOnCubeException(
                     "That both of the two sides of the BinaryTupleExpression own columns is not supported for "
                             + operator.toString());
         }
@@ -72,7 +73,7 @@ public class BinaryTupleExpression extends TupleExpression {
 
     private void verifyDivide() {
         if (ExpressionColCollector.collectMeasureColumns(getRight()).size() > 0) {
-            throw new IllegalArgumentException(
+            throw new QueryOnCubeException(
                     "That the right side of the BinaryTupleExpression owns columns is not supported for "
                             + operator.toString());
         }

--- a/core-metadata/src/test/java/org/apache/kylin/metadata/expression/TupleExpressionTest.java
+++ b/core-metadata/src/test/java/org/apache/kylin/metadata/expression/TupleExpressionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import java.math.BigDecimal;
 
 import org.apache.kylin.common.util.LocalFileMetadataTestCase;
+import org.apache.kylin.exception.QueryOnCubeException;
 import org.apache.kylin.metadata.model.TableDesc;
 import org.apache.kylin.metadata.model.TblColRef;
 import org.junit.AfterClass;
@@ -65,8 +66,8 @@ public class TupleExpressionTest extends LocalFileMetadataTestCase {
                 Lists.newArrayList(constTuple2, colTuple2));
         try {
             biTuple2.verify();
-            fail("IllegalArgumentException should be thrown");
-        } catch (IllegalArgumentException e) {
+            fail("QueryOnCubeException should be thrown，That the right side of the BinaryTupleExpression owns columns is not supported for /");
+        } catch (QueryOnCubeException e) {
         }
 
         biTuple2 = new BinaryTupleExpression(TupleExpression.ExpressionOperatorEnum.DIVIDE,
@@ -77,8 +78,8 @@ public class TupleExpressionTest extends LocalFileMetadataTestCase {
                 Lists.<TupleExpression> newArrayList(biTuple1, biTuple2));
         try {
             biTuple.verify();
-            fail("IllegalArgumentException should be thrown");
-        } catch (IllegalArgumentException e) {
+            fail("QueryOnCubeException should be thrown，That both of the two sides of the BinaryTupleExpression own columns is not supported for *");
+        } catch (QueryOnCubeException e) {
         }
     }
 }

--- a/query/src/main/java/org/apache/kylin/query/util/PushDownUtil.java
+++ b/query/src/main/java/org/apache/kylin/query/util/PushDownUtil.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.util.ClassUtil;
 import org.apache.kylin.common.util.Pair;
+import org.apache.kylin.exception.QueryOnCubeException;
 import org.apache.kylin.metadata.model.tool.CalciteParser;
 import org.apache.kylin.metadata.project.ProjectManager;
 import org.apache.kylin.metadata.querymeta.SelectedColumnMeta;
@@ -143,7 +144,8 @@ public class PushDownUtil {
             return (rootCause != null //
                     && (rootCause instanceof NoRealizationFoundException //
                             || rootCause instanceof SqlValidatorException //
-                            || rootCause instanceof RoutingIndicatorException)); //
+                            || rootCause instanceof RoutingIndicatorException //
+                            || rootCause instanceof QueryOnCubeException)); //
         }
     }
 


### PR DESCRIPTION
Scene：

SQL:select round (car_dismatch_cnt*100/answer_order_cnt, 4) from db.table1.

- 1、Executes the SQL on a  project where its cube has db.table1,it will throws the right side of the BinaryTuple Expressions columns is not supported for / exception and is not queried through pushdown;

- 2、When change a project where not create the table cube , the same query  can be executed to push down and get the right result.

- 3、 Expect that no matter whether a table cube is created or not, when the cube query is not success, the result can still be obtained by pushdown query, which will give users a consistent experience.