### PR TITLE
remove htableName toUpperCase(), because HBase tableName is case sens…

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
@@ -53,8 +53,6 @@ import org.apache.kylin.storage.hbase.HBaseConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Locale;
-
 import static org.apache.hadoop.hbase.HBaseConfiguration.merge;
 
 /**
@@ -106,7 +104,7 @@ public class CubeHFileJob extends AbstractHadoopJob {
 
             Configuration hbaseConf = HBaseConfiguration.create(getConf());
 
-            String hTableName = getOptionValue(OPTION_HTABLE_NAME).toUpperCase(Locale.ROOT);
+            String hTableName = getOptionValue(OPTION_HTABLE_NAME);
             connection = ConnectionFactory.createConnection(hbaseConf);
             Table table = connection.getTable(TableName.valueOf(hTableName));
             RegionLocator regionLocator = connection.getRegionLocator(TableName.valueOf(hTableName));


### PR DESCRIPTION
**Description**
HBase is case sensitive，tableName.toUpperCase() will lead to the created table could not be found.
If my tableName of HBase is lowercase, kylin can't find the table created in the HFile generated step.

**Improvement**
just remove toUpperCase() for HBase tableName on 2.6.x-hadoop3.1.