### PR TITLE
Bug fix: remove htableName toUpperCase, becase HBasse tableName is case sensitive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
         <version>19</version>
-        <relativePath />
+        <relativePath/>
         <!-- no parent resolution -->
     </parent>
 
@@ -122,6 +123,7 @@
         <jetty.version>9.3.22.v20171030</jetty.version>
         <jamm.version>0.3.1</jamm.version>
         <mockito.version>2.7.14</mockito.version>
+        <mockito-all.version>1.9.5</mockito-all.version>
         <powermock.version>1.7.0</powermock.version>
 
         <!-- Commons -->
@@ -129,6 +131,7 @@
         <commons-email.version>1.5</commons-email.version>
         <commons-validator.version>1.4.0</commons-validator.version>
         <commons-compress>1.18</commons-compress>
+        <commons-dbcp.version>1.4</commons-dbcp.version>
 
         <!-- Utility -->
         <log4j.version>1.2.17</log4j.version>
@@ -146,6 +149,8 @@
         <t-digest.version>3.1</t-digest.version>
         <freemarker.version>2.3.23</freemarker.version>
         <rocksdb.version>5.9.2</rocksdb.version>
+        <lz4.version>1.3.0</lz4.version>
+        <mssql-jdbc.version>6.2.2.jre8</mssql-jdbc.version>
         <!--metric-->
         <dropwizard.version>3.1.2</dropwizard.version>
         <!-- REST Service, ref https://github.com/spring-projects/spring-boot/blob/v1.3.8.RELEASE/spring-boot-dependencies/pom.xml -->
@@ -398,6 +403,33 @@
                 <version>${project.version}</version>
                 <type>test-jar</type>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.kylin</groupId>
+                <artifactId>kylin-stream-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kylin</groupId>
+                <artifactId>kylin-stream-coordinator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kylin</groupId>
+                <artifactId>kylin-stream-source-kafka</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kylin</groupId>
+                <artifactId>kylin-storage-stream</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kylin</groupId>
+                <artifactId>kylin-stream-receiver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.kylin</groupId>
                 <artifactId>kylin-datasource-sdk</artifactId>
@@ -901,12 +933,6 @@
                 <artifactId>opensaml</artifactId>
                 <version>${opensaml.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.curator</groupId>
-                <artifactId>curator-test</artifactId>
-                <version>2.12.0</version>
-                <scope>test</scope>
-            </dependency>
 
             <!-- Spring Core -->
             <dependency>
@@ -970,17 +996,15 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
                 <version>${jetty.version}</version>
-                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
                 <version>${jetty.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -1015,11 +1039,6 @@
                 <version>${scala.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-reflect</artifactId>
-                <version>${scala.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-reflect</artifactId>
@@ -1266,7 +1285,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>

--- a/server-base/pom.xml
+++ b/server-base/pom.xml
@@ -248,11 +248,6 @@
             <artifactId>jetty-webapp</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/server-base/src/main/java/org/apache/kylin/rest/service/CubeService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/CubeService.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.persistence.RootPersistentEntity;
 import org.apache.kylin.common.util.CliCommandExecutor;
@@ -623,8 +623,8 @@ public class CubeService extends BasicService implements InitializingBean {
                 toDropHTables.add(seg.getStorageLocationIdentifier());
                 toDelHDFSPaths.add(JobBuilderSupport.getJobWorkingDir(seg.getConfig().getHdfsWorkingDirectory(), seg.getLastBuildJobID()));
             }
-
-            StorageCleanUtil.dropHTables(new HBaseAdmin(HBaseConnection.getCurrentHBaseConfiguration()), toDropHTables);
+            Connection conn = HBaseConnection.get(KylinConfig.getInstanceFromEnv().getStorageUrl());
+            StorageCleanUtil.dropHTables(conn.getAdmin(), toDropHTables);
             StorageCleanUtil.deleteHDFSPath(HadoopUtil.getWorkingFileSystem(), toDelHDFSPaths);
         }
     }

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/steps/CubeHFileJob.java
@@ -53,8 +53,6 @@ import org.apache.kylin.storage.hbase.HBaseConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Locale;
-
 import static org.apache.hadoop.hbase.HBaseConfiguration.merge;
 
 /**
@@ -106,7 +104,7 @@ public class CubeHFileJob extends AbstractHadoopJob {
 
             Configuration hbaseConf = HBaseConfiguration.create(getConf());
 
-            String hTableName = getOptionValue(OPTION_HTABLE_NAME).toUpperCase(Locale.ROOT);
+            String hTableName = getOptionValue(OPTION_HTABLE_NAME);
             connection = ConnectionFactory.createConnection(hbaseConf);
             Table table = connection.getTable(TableName.valueOf(hTableName));
             RegionLocator regionLocator = connection.getRegionLocator(TableName.valueOf(hTableName));

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/StorageCleanUtil.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/StorageCleanUtil.java
@@ -21,7 +21,8 @@ package org.apache.kylin.storage.hbase.util;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,18 +36,18 @@ public class StorageCleanUtil {
     /**
      * this method will close hbaseAdmin after finishing the work.
      */
-    public static void dropHTables(final HBaseAdmin hbaseAdmin, List<String> hTables) {
+    public static void dropHTables(final Admin hbaseAdmin, List<String> hTables) {
         runSingleThreadTaskQuietly(() -> {
             try {
                 for (String htable : hTables) {
                     logger.info("Deleting HBase table {}", htable);
 
-                    if (hbaseAdmin.tableExists(htable)) {
-                        if (hbaseAdmin.isTableEnabled(htable)) {
-                            hbaseAdmin.disableTable(htable);
+                    if (hbaseAdmin.tableExists(TableName.valueOf(htable))) {
+                        if (hbaseAdmin.isTableEnabled(TableName.valueOf(htable))) {
+                            hbaseAdmin.disableTable(TableName.valueOf(htable));
                         }
 
-                        hbaseAdmin.deleteTable(htable);
+                        hbaseAdmin.deleteTable(TableName.valueOf(htable));
                         logger.info("Deleted HBase table {}", htable);
                     } else {
                         logger.info("HBase table {} does not exist.", htable);


### PR DESCRIPTION
**Description**
HBase is case sensitive，tableName.toUpperCase() will lead to the created table could not be found.
If my tableName of HBase is lowercase, kylin can't find the table created in the HFile generated step.

**Improvement**
just remove toUpperCase() for HBase tableName on master-hadoop3.1.