### PR TITLE
Minor, add Hive JDBC dependency for DebugTomcat

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -92,6 +92,22 @@
             <artifactId>mysql-connector-java</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Test & Env -->
         <dependency>


### PR DESCRIPTION
Cubing job will failed with kylin.source.hive.client=beeline when I launch Kylin Server locally.