### PR TITLE
[KYLIN-3519] Upgrade Jacoco version to 0.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <forbiddenapis.version>2.3</forbiddenapis.version>
 
     <!-- Sonar -->
-    <jacoco.version>0.8.0</jacoco.version>
+    <jacoco.version>0.8.2</jacoco.version>
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <sonar.jacoco.reportPaths>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPaths>


### PR DESCRIPTION
Jacoco 0.8.2 adds Java 11 support. We should upgrade Jacoco.