### PR TITLE
[KYLIN-2517] Upgrade Apache Hbase version to 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <hive-hcatalog.version>1.2.1</hive-hcatalog.version>
 
     <!-- HBase versions -->
-    <hbase-hadoop2.version>1.1.1</hbase-hadoop2.version>
+    <hbase-hadoop2.version>1.4.7</hbase-hadoop2.version>
 
     <!-- Kafka versions -->
     <kafka.version>1.0.0</kafka.version>


### PR DESCRIPTION
There have been major enhancements / bug fixes since the hbase 1.1.1 release.
We should upgrade to it 1.4.7.