### PR TITLE
KYLIN-3628 Fix unexpected exception for select from Lookup Table

### DIFF
--- a/query/src/main/java/org/apache/kylin/query/enumerator/LookupTableEnumerator.java
+++ b/query/src/main/java/org/apache/kylin/query/enumerator/LookupTableEnumerator.java
@@ -60,7 +60,7 @@ public class LookupTableEnumerator implements Enumerator<Object[]> {
             List<RealizationEntry> realizationEntries = project.getRealizationEntries();
             String lookupTableName = olapContext.firstTableScan.getTableName();
             CubeManager cubeMgr = CubeManager.getInstance(cube.getConfig());
-            cube = cubeMgr.findLatestSnapshot(realizationEntries, lookupTableName);
+            cube = cubeMgr.findLatestSnapshot(realizationEntries, lookupTableName, cube);
             olapContext.realization = cube;
         } else if (olapContext.realization instanceof HybridInstance) {
             final HybridInstance hybridInstance = (HybridInstance) olapContext.realization;


### PR DESCRIPTION
In some case, cube returned by findLatestSnapshot didn't contains the snapshot table
for what you need. Because some dimension which exists in model but was removed in cube design phase, query such as "select * from LookupTable" will throw unexpected exception and confused user.