### PR TITLE
Upgraded avatica/calcite version

### DIFF
--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinResultSet.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinResultSet.java
@@ -39,7 +39,7 @@ import org.apache.kylin.jdbc.IRemoteClient.QueryResult;
 
 public class KylinResultSet extends AvaticaResultSet {
 
-    public KylinResultSet(AvaticaStatement statement, QueryState state, Signature signature, ResultSetMetaData resultSetMetaData, TimeZone timeZone, Frame firstFrame) {
+    public KylinResultSet(AvaticaStatement statement, QueryState state, Signature signature, ResultSetMetaData resultSetMetaData, TimeZone timeZone, Frame firstFrame) throws SQLException {
         super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 
     <!-- Calcite Version, the kylin fork is: https://github.com/Kyligence/calcite -->
     <calcite.version>1.16.0-kylin-r2</calcite.version>
-    <avatica.version>1.10.0</avatica.version>
+    <avatica.version>1.12.0</avatica.version>
 
     <!-- Hadoop Common deps, keep compatible with hadoop2.version -->
     <zookeeper.version>3.4.13</zookeeper.version>


### PR DESCRIPTION
JDBC driver fails either in Tableau or Apache Drill - the issue is that KylinConnection class derived from AvaticaConnection throws NonImplementedException for isValid method in Avatica 1.10 - that was fixed in Avatica 1.12 in this commit https://github.com/apache/calcite-avatica/commit/50d45f989ee7a8eae0456dee7a88c5fa4d9d8b5a#diff-88cfeb980a0b86ea07f69cb4f3352646L376. 

After upgrading to avatica 1.12 Tableau is able to connect to Kylin.