### PR TITLE
KYLIN-4081 Use absolute path instead of relative for local segment cache

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -2200,6 +2200,18 @@ public abstract class KylinConfigBase implements Serializable {
         return getOptional("kylin.stream.settled.storage", null);
     }
 
+    public String getStreamMetrics() {
+        return getOptional("kylin.stream.metrics.option", "");
+    }
+
+    public long getStreamMetricsInterval() {
+        return Long.parseLong(getOptional("kylin.stream.metrics.interval", "5"));
+    }
+
+    // ============================================================================
+    // Health Check CLI
+    // ============================================================================
+
     public int getWarningSegmentNum() {
         return Integer.parseInt(getOptional("kylin.tool.health-check.warning-segment-num", "-1"));
     }

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/consumer/StreamingConsumerChannel.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/consumer/StreamingConsumerChannel.java
@@ -144,7 +144,8 @@ public class StreamingConsumerChannel implements Runnable {
 
     private void removeMetrics() {
         for (Map.Entry<Integer, Meter> meterEntry : eventConsumeMeters.entrySet()) {
-            StreamingMetrics.getInstance().getMetrics().remove(MetricRegistry.name(StreamingMetrics.CONSUME_RATE_PFX,
+            StreamingMetrics.getInstance().getMetricRegistry().remove(MetricRegistry
+                    .name(StreamingMetrics.CONSUME_RATE_PFX,
                     cubeName, String.valueOf(meterEntry.getKey())));
         }
     }

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/StreamingSegmentManager.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/StreamingSegmentManager.java
@@ -172,8 +172,8 @@ public class StreamingSegmentManager implements Closeable {
         latestEventIngestTime = currentTime;
         segment.addEvent(event);
         segment.setLastUpdateTime(currentTime);
-        if (event.getTimestamp() > latestEventTime) {
-            latestEventTime = event.getTimestamp();
+        if (eventTime > latestEventTime) {
+            latestEventTime = eventTime;
         }
         ingestCount.incrementAndGet();
         // update the segment start source position
@@ -431,8 +431,6 @@ public class StreamingSegmentManager implements Closeable {
 
     /**
      * get the smallest source offsets in all other segments that larger than the specified segment
-     * @param currSegment
-     * @return
      */
     public ISourcePosition getSmallestSourcePosition(StreamingCubeSegment currSegment) {
         List<ISourcePosition> allSegmentStartPositions = Lists.newArrayList();
@@ -558,7 +556,7 @@ public class StreamingSegmentManager implements Closeable {
 
     @Override
     public void close() {
-        logger.warn("Closing Streaming Cube store, cubeName=" + cubeName);
+        logger.warn("Closing Streaming Cube store, cubeName={}", cubeName);
         checkpoint();
         logger.warn("{} ingested {} , dropped {}, long latency {}", cubeName, ingestCount.get(), dropCounts.get(),
                 longLatencyInfo.getTotalLongLatencyEventCnt());
@@ -601,7 +599,7 @@ public class StreamingSegmentManager implements Closeable {
         }
         cp.setSegmentSourceStartPosition(segmentSourceStartPosStr);
         if (logger.isInfoEnabled()) {
-            logger.info("Print check point for cube " + cubeName + " ," + cp.toString());
+            logger.info("Print check point for cube {}", cubeName + " ," + cp.toString());
         }
 
         checkPointStore.saveCheckPoint(cp);

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStore.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStore.java
@@ -109,7 +109,7 @@ public class ColumnarSegmentStore implements IStreamingSegmentStore {
         try {
             StreamingMetrics
                     .getInstance()
-                    .getMetrics()
+                    .getMetricRegistry()
                     .register(MetricRegistry.name("streaming.inMem.row.cnt", cubeInstance.getName(), segmentName),
                             new Gauge<Integer>() {
                                 @Override
@@ -447,7 +447,7 @@ public class ColumnarSegmentStore implements IStreamingSegmentStore {
 
     public void close() throws IOException {
         logger.warn("closing the streaming cube segment, cube {}, segment {}.", cubeName, segmentName);
-        StreamingMetrics.getInstance().getMetrics()
+        StreamingMetrics.getInstance().getMetricRegistry()
                 .remove(MetricRegistry.name("streaming.inMem.row.cnt", cubeName, segmentName));
     }
 

--- a/stream-receiver/src/main/java/org/apache/kylin/stream/server/StreamingServer.java
+++ b/stream-receiver/src/main/java/org/apache/kylin/stream/server/StreamingServer.java
@@ -118,15 +118,14 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
     private ScheduledExecutorService segmentStateCheckerExecutor;
     private ExecutorService segmentFlushExecutor;
 
-    private String baseStorePath;
+    private final String baseStorePath;
 
     private StreamingServer() {
         streamZKClient = StreamingUtils.getZookeeperClient();
         streamMetadataStore = StreamMetadataStoreFactory.getStreamMetaDataStore();
         coordinatorClient = new HttpCoordinatorClient(streamMetadataStore);
         currentNode = NodeUtil.getCurrentNode(DEFAULT_PORT);
-        baseStorePath = KylinConfig.getInstanceFromEnv().getStreamingIndexPath();
-
+        baseStorePath = calLocalSegmentCacheDir();
         segmentStateCheckerExecutor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(
                 "segment_state_check"));
         segmentFlushExecutor = Executors.newFixedThreadPool(5, new NamedThreadFactory("segment_flush"));
@@ -290,7 +289,7 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
     }
 
     private void registerReceiver() throws Exception {
-        logger.info("register receiver:" + currentNode);
+        logger.info("register receiver: {}", currentNode);
         streamMetadataStore.addReceiver(currentNode);
     }
 
@@ -352,7 +351,7 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
     }
 
     public synchronized ConsumerStatsResponse stopConsumer(String cube) {
-        logger.info("stop consumers for cube: " + cube);
+        logger.info("stop consumers for cube: {}", cube);
         ConsumerStatsResponse response = new ConsumerStatsResponse();
         StreamingConsumerChannel consumer = cubeConsumerMap.get(cube);
         if (consumer != null) {
@@ -372,7 +371,7 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
     }
 
     public synchronized ConsumerStatsResponse pauseConsumer(String cubeName) {
-        logger.info("pause consumers for cube: " + cubeName);
+        logger.info("pause consumers for cube: {}", cubeName);
         ConsumerStatsResponse response = new ConsumerStatsResponse();
         response.setCubeName(cubeName);
         StreamingConsumerChannel consumer = cubeConsumerMap.get(cubeName);
@@ -380,18 +379,18 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
             consumer.pause(true);
             response.setConsumePosition(consumer.getSourceConsumeInfo());
         } else {
-            logger.warn("the consumer for cube:{} does not exist " + cubeName);
+            logger.warn("the consumer for cube:{} does not exist ", cubeName);
         }
         return response;
     }
 
     public synchronized ConsumerStatsResponse resumeConsumer(String cubeName, String resumeToPosition) {
-        logger.info("resume consumers for cube: " + cubeName);
+        logger.info("resume consumers for cube: {}", cubeName);
         ConsumerStatsResponse response = new ConsumerStatsResponse();
         response.setCubeName(cubeName);
         StreamingConsumerChannel consumer = cubeConsumerMap.get(cubeName);
         if (consumer == null) {
-            logger.warn("the consumer for cube:{} does not exist " + cubeName);
+            logger.warn("the consumer for cube:{} does not exist", cubeName);
             return response;
         }
         KylinConfig kylinConfig = KylinConfig.getInstanceFromEnv();
@@ -695,6 +694,26 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
                 cubeInstance.getRootFactTable());
     }
 
+    private String calLocalSegmentCacheDir() {
+        String kylinHome = KylinConfig.getKylinHome();
+        String indexPathStr = KylinConfig.getInstanceFromEnv().getStreamingIndexPath();
+        String localSegmentCachePath;
+        File indexPath = new File(indexPathStr);
+
+        if (indexPath.isAbsolute()) {
+            localSegmentCachePath = indexPathStr;
+        } else {
+            if (kylinHome != null && !kylinHome.equals("")) {
+                File localSegmentFile = new File(kylinHome, indexPathStr);
+                localSegmentCachePath = localSegmentFile.getAbsolutePath();
+            } else {
+                localSegmentCachePath = indexPathStr;
+            }
+        }
+        logger.info("Using {} to store local segment cache.", localSegmentCachePath);
+        return localSegmentCachePath;
+    }
+
     private static class SegmentHDFSFlusher implements Runnable {
         private final Logger logger = LoggerFactory.getLogger(SegmentHDFSFlusher.class);
         private StreamingCubeSegment segment;
@@ -719,9 +738,9 @@ public class StreamingServer implements ReplicaSetLeaderSelector.LeaderChangeLis
             if (fs.exists(remoteTempPath)) {
                 FileStatus sdst = fs.getFileStatus(remoteTempPath);
                 if (sdst.isDirectory()) {
-                    logger.warn("target temp path:" + remoteTempPath + " is an existed directory, try to delete it.");
+                    logger.warn("target temp path: {} is an existed directory, try to delete it.", remoteTempPath);
                     fs.delete(remoteTempPath, true);
-                    logger.warn("target temp path:" + remoteTempPath + " is deleted.");
+                    logger.warn("target temp path: {} is deleted.", remoteTempPath);
                 }
             }
             fs.copyFromLocalFile(new Path(localPath), remoteTempPath);


### PR DESCRIPTION
Use absolute path instead of relative path for local segment cache may cause unpredicted result. After restart receiver, if working directory change, Receiver cannot find segment data/checkpoint which created previously, and recreate new one, which is a serious problem.