### PR TITLE
KYLIN-4084 Reset kylin.stream.node in kylin-port-replace-util.sh

### DIFF
--- a/build/bin/kylin-port-replace-util.sh
+++ b/build/bin/kylin-port-replace-util.sh
@@ -89,6 +89,11 @@ then
     #replace ports in kylin.properties
     new_kylin_port=`expr ${KYLIN_DEFAULT_PORT} + ${OFFSET}`
 
+    #replace kylin.stream.node for Streaming Coordinator
+    stream_node="kylin.stream.node=`hostname -f`:$new_kylin_port"
+    echo "Using new kylin.stream.node: $stream_node"
+    sed -i "s/^kylin\.stream\.node=.*$/$stream_node/g" ${KYLIN_CONFIG_FILE}
+
     sed -i "s/#*kylin.server.cluster-servers=\(.*\).*:\(.*\)/kylin.server.cluster-servers=\1:${new_kylin_port}/g" ${KYLIN_CONFIG_FILE}
 
     echo "New kylin port is : ${new_kylin_port}"


### PR DESCRIPTION
In Kylin3.0, we introduce new real-time OLAP feature. When you use "kylin-port-replace-util.sh" to change listen port used by Kylin and use "kylin.sh start" to start a Coordinator. If you
forget to set "kylin.stream.node" to new port, Coordinator will register its address into ZK using wrong port, that will make receiver cannot connect to Coordinator. That will create a mis-understand exception in all receivers and confused user.