### PR TITLE
KYLIN-3901: Use multi threads to speed up the storage cleanup job

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtil.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtil.java
@@ -48,13 +48,18 @@ public class StorageCleanJobHbaseUtil {
     protected static final Logger logger = LoggerFactory.getLogger(StorageCleanJobHbaseUtil.class);
 
     @SuppressWarnings("deprecation")
-    public static List<String> cleanUnusedHBaseTables(boolean delete, int deleteTimeout) throws IOException {
+    public static List<String> cleanUnusedHBaseTables(boolean delete, int deleteTimeout, int threadsNum) throws IOException {
         try (HBaseAdmin hbaseAdmin = new HBaseAdmin(HBaseConfiguration.create())) {
-            return cleanUnusedHBaseTables(hbaseAdmin, delete, deleteTimeout);
+            return cleanUnusedHBaseTables(hbaseAdmin, delete, deleteTimeout, threadsNum);
         }
     }
 
     static List<String> cleanUnusedHBaseTables(HBaseAdmin hbaseAdmin, boolean delete, int deleteTimeout) throws IOException {
+        return cleanUnusedHBaseTables(hbaseAdmin, delete, deleteTimeout, 1);
+    }
+
+    static List<String> cleanUnusedHBaseTables(HBaseAdmin hbaseAdmin, boolean delete, int deleteTimeout,
+        int threadsNum) throws IOException {
         KylinConfig config = KylinConfig.getInstanceFromEnv();
         CubeManager cubeMgr = CubeManager.getInstance(config);
         
@@ -106,7 +111,8 @@ public class StorageCleanJobHbaseUtil {
         }
         if (delete) {
             // drop tables
-            ExecutorService executorService = Executors.newSingleThreadExecutor();
+            logger.info("Use {} threads to drop unused hbase tables", threadsNum);
+            ExecutorService executorService = Executors.newFixedThreadPool(threadsNum);
             for (String htableName : allTablesNeedToBeDropped) {
                 FutureTask futureTask = new FutureTask(new DeleteHTableRunnable(hbaseAdmin, htableName));
                 executorService.execute(futureTask);

--- a/server-base/src/test/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtilTest.java
+++ b/server-base/src/test/java/org/apache/kylin/rest/job/StorageCleanJobHbaseUtilTest.java
@@ -66,7 +66,7 @@ public class StorageCleanJobHbaseUtilTest {
 
         when(hBaseAdmin.tableExists(toBeDel)).thenReturn(true);
         when(hBaseAdmin.isTableEnabled(toBeDel)).thenReturn(false);
-        StorageCleanJobHbaseUtil.cleanUnusedHBaseTables(hBaseAdmin, true, 100000);
+        StorageCleanJobHbaseUtil.cleanUnusedHBaseTables(hBaseAdmin, true, 100000, 1);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(hBaseAdmin).deleteTable(captor.capture());


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-3901

The pr only implement the multi-thread cleanup for hbase tables