### PR TITLE
Update howto_backup_metadata.cn.md

### DIFF
--- a/website/_docs/howto/howto_backup_metadata.cn.md
+++ b/website/_docs/howto/howto_backup_metadata.cn.md
@@ -30,8 +30,8 @@ Kylin使用`resource root path + resource name + resource suffix`作为key值(HB
 | /table              | /DATABASE.TABLE--project name | .json |
 | /table_exd          | /DATABASE.TABLE--project name | .json |
 | /execute            | /job id               |  |
-| /execute_out        | /job id-step index    |  |
-| /kafaka             | /DATABASE.TABLE       | .json |
+| /execute_output     | /job id-step index    |  |
+| /kafka              | /DATABASE.TABLE       | .json |
 | /streaming          | /DATABASE.TABLE       | .json |
 | /user               | /user name            |  |
 


### PR DESCRIPTION
Fix two Resource root path typos which have been already fixed in the corresponding English version.