### PR TITLE
KYLIN-4112: Add hdfs keberos token delegation in Spark to support se and MR use different HDFS clusters

### DIFF
--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java
@@ -267,6 +267,16 @@ public class SparkExecutable extends AbstractExecutable {
                 sparkConfs.putAll(sparkSpecificConfs);
             }
 
+            // Add hbase fs to spark conf: spark.yarn.access.hadoopFileSystems
+            if (StringUtils.isNotEmpty(config.getHBaseClusterFs())) {
+                String fileSystems = sparkConfs.get("spark.yarn.access.hadoopFileSystems");
+                if (StringUtils.isNotEmpty(fileSystems)) {
+                    sparkConfs.put("spark.yarn.access.hadoopFileSystems", fileSystems + "," + config.getHBaseClusterFs());
+                } else {
+                    sparkConfs.put("spark.yarn.access.hadoopFileSystems", config.getHBaseClusterFs());
+                }
+            }
+
             for (Map.Entry<String, String> entry : sparkConfs.entrySet()) {
                 stringBuilder.append(" --conf ").append(entry.getKey()).append("=").append(entry.getValue())
                         .append(" ");


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/KYLIN-4112