### PR TITLE
KYLIN-4117 Auto adjust data type of RelNode for intersect_count

### DIFF
--- a/kylin-it/src/test/resources/query/sql_intersect_count/query01.sql
+++ b/kylin-it/src/test/resources/query/sql_intersect_count/query01.sql
@@ -16,12 +16,12 @@
 -- limitations under the License.
 --
 select CAL_DT,
-intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array[date'2012-01-01']) as first_day,
-intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array[date'2012-01-02']) as second_day,
-intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array[date'2012-01-03']) as third_day,
-intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array[date'2012-01-01',date'2012-01-02']) as retention_oneday,
-intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array[date'2012-01-01',date'2012-01-02',date'2012-01-03']) as retention_twoday
+intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array['2012-01-01']) as first_day,
+intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array['2012-01-02']) as second_day,
+intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array['2012-01-03']) as third_day,
+intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array['2012-01-01','2012-01-02']) as retention_oneday,
+intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array['2012-01-01','2012-01-02','2012-01-03']) as retention_twoday
 from test_kylin_fact
-where CAL_DT in (date'2012-01-01',date'2012-01-02',date'2012-01-03')
+where CAL_DT in ('2012-01-01','2012-01-02','2012-01-03')
 group by CAL_DT
 

--- a/kylin-it/src/test/resources/query/sql_intersect_count/query03.sql
+++ b/kylin-it/src/test/resources/query/sql_intersect_count/query03.sql
@@ -16,8 +16,8 @@
 -- limitations under the License.
 --
 select LEAF_CATEG_ID,
-intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array[date'2012-01-01']) as first_day
+intersect_count(TEST_COUNT_DISTINCT_BITMAP, CAL_DT, array['2012-01-01']) as first_day
 from test_kylin_fact
-where CAL_DT in (date'2012-01-01',date'2012-01-02',date'2012-01-03')
+where CAL_DT in ('2012-01-01','2012-01-02','2012-01-03')
 group by LEAF_CATEG_ID
 


### PR DESCRIPTION
### Issue description

In query of intersect_count, says `intersect_count(OPS_USER_ID, part_dt, array[date '2012-01-01',date '2012-01-02'])`, we need to specific data type of each entry in array, if *date* miss, return value will be 0, which will mislead user. So I think we should auto adjust data type of each entry from string/char to real data type.

![image](https://user-images.githubusercontent.com/14030549/62407675-1a9fc400-b5ef-11e9-9e6d-77c9c89436cc.png)
