### PR TITLE
添加当天作业过滤

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -1906,7 +1906,7 @@ public abstract class KylinConfigBase implements Serializable {
                 + "kylin.security.profile,"
                 + "kylin.htrace.show-gui-trace-toggle,kylin.web.export-allow-admin,kylin.web.export-allow-other,"
                 + "kylin.cube.cubeplanner.enabled,kylin.web.dashboard-enabled,kylin.tool.auto-migrate-cube.enabled,"
-                + "kylin.job.scheduler.default");
+                + "kylin.job.scheduler.default,kylin.web.default-time-filter");
     }
 
     // ============================================================================

--- a/core-common/src/main/resources/kylin-defaults.properties
+++ b/core-common/src/main/resources/kylin-defaults.properties
@@ -77,6 +77,9 @@ kylin.web.link-diagnostic=
 kylin.web.contact-mail=
 kylin.server.external-acl-provider=
 
+# Default time filter for job list, 0->current day, 1->last one day, 2->last one week, 3->last one year, 4->all
+kylin.web.default-time-filter=1
+
 ### SOURCE ###
 
 # Hive client, valid value [cli, beeline]

--- a/core-job/src/main/java/org/apache/kylin/job/constant/JobTimeFilterEnum.java
+++ b/core-job/src/main/java/org/apache/kylin/job/constant/JobTimeFilterEnum.java
@@ -19,7 +19,7 @@
 package org.apache.kylin.job.constant;
 
 public enum JobTimeFilterEnum {
-    LAST_ONE_DAY(0), LAST_ONE_WEEK(1), LAST_ONE_MONTH(2), LAST_ONE_YEAR(3), ALL(4);
+    CURRENT_DAY(0), LAST_ONE_DAY(1), LAST_ONE_WEEK(2), LAST_ONE_MONTH(3), LAST_ONE_YEAR(4), ALL(5);
 
     private final int code;
 

--- a/examples/test_case_data/sandbox/kylin.properties
+++ b/examples/test_case_data/sandbox/kylin.properties
@@ -171,6 +171,9 @@ kylin.web.export-allow-other=true
 # Hide measures in measure list of cube designer, separate by comma
 kylin.web.hide-measures=RAW
 
+# Default time filter for job list, 0->current day, 1->last one day, 2->last one week, 3->last one year, 4->all
+kylin.web.default-time-filter=0
+
 ### OTHER ###
 
 # kylin query metrics percentiles intervals default=60, 300, 3600

--- a/server-base/src/main/java/org/apache/kylin/rest/service/JobService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/JobService.java
@@ -194,6 +194,12 @@ public class JobService extends BasicService implements InitializingBean {
         case LAST_ONE_YEAR:
             calendar.add(Calendar.YEAR, -1);
             return calendar.getTimeInMillis();
+        case CURRENT_DAY:
+            calendar.add(Calendar.DAY_OF_MONTH, 0);
+            calendar.set(Calendar.HOUR_OF_DAY, 0);
+            calendar.set(Calendar.MINUTE, 0);
+            calendar.set(Calendar.SECOND, 0);
+            return calendar.getTimeInMillis();
         case ALL:
             return 0;
         default:

--- a/webapp/app/js/controllers/dashboard.js
+++ b/webapp/app/js/controllers/dashboard.js
@@ -22,7 +22,6 @@ KylinApp.controller('DashboardCtrl', function ($scope, $location, storage, kylin
 
   $scope.init = function(){
     $scope.timezone = 'GMT';
-
     // Init date range
     storage.bind($scope, 'dateRange', {defaultValue: {
       startDate: moment().subtract(7, 'days').clone().tz($scope.timezone).startOf('day').format('x'),
@@ -183,12 +182,12 @@ KylinApp.controller('DashboardCtrl', function ($scope, $location, storage, kylin
               value.color = '#ddd';
             }
           });
-        } 
+        }
       }, function(e) {
           SweetAlert.swal('Oops...', 'Failed to load bar chart.', 'error');
           console.error('bar chart error:', e.data);
       });
-    }    
+    }
   };
 
   // Clean and remove chart
@@ -210,7 +209,7 @@ KylinApp.controller('DashboardCtrl', function ($scope, $location, storage, kylin
 
   // Click query count square
   $scope.queryCountChart = function() {
-    $scope.currentSquare = 'queryCount'; 
+    $scope.currentSquare = 'queryCount';
     $scope.barchartCategory = dashboardConfig.categories[0];
     $scope.barchartMetric = dashboardConfig.metrics[0];
     $scope.linechartCategory = dashboardConfig.categories[0];

--- a/webapp/app/js/controllers/page.js
+++ b/webapp/app/js/controllers/page.js
@@ -25,7 +25,8 @@ KylinApp.controller('PageCtrl', function ($scope, $q, AccessService, $modal, $lo
     $log.debug(data);
     kylinConfig.initWebConfigInfo();
     $rootScope.isShowCubeplanner = kylinConfig.getProperty('kylin.cube.cubeplanner.enabled') === 'true';
-    $rootScope.isShowDashboard = kylinConfig.getProperty('kylin.web.dashboard-enabled') === 'true'
+    $rootScope.isShowDashboard = kylinConfig.getProperty('kylin.web.dashboard-enabled') === 'true';
+    JobList.jobFilter.timeFilterId = kylinConfig.getJobTimeFilterId();
   });
   $rootScope.userAction = {
     'islogout': false

--- a/webapp/app/js/model/jobConfig.js
+++ b/webapp/app/js/model/jobConfig.js
@@ -27,11 +27,12 @@ KylinApp.constant('jobConfig', {
     {name: 'DISCARDED', value: 16}
   ],
   timeFilter: [
-    {name: 'LAST ONE DAY', value: 0},
-    {name: 'LAST ONE WEEK', value: 1},
-    {name: 'LAST ONE MONTH', value: 2},
-    {name: 'LAST ONE YEAR', value: 3},
-    {name: 'ALL', value: 4},
+    {name: 'CURRENT DAY', value: 0},
+    {name: 'LAST ONE DAY', value: 1},
+    {name: 'LAST ONE WEEK', value: 2},
+    {name: 'LAST ONE MONTH', value: 3},
+    {name: 'LAST ONE YEAR', value: 4},
+    {name: 'ALL', value: 5},
   ],
   theaditems: [
     {attr: 'name', name: 'Job Name'},

--- a/webapp/app/js/model/jobListModel.js
+++ b/webapp/app/js/model/jobListModel.js
@@ -20,12 +20,12 @@
  *jobListModel will manage data in list job page
  */
 
-KylinApp.service('JobList',function(JobService,$q){
+KylinApp.service('JobList',function(JobService, $q, kylinConfig){
     var _this = this;
     this.jobs={};
     this.jobFilter = {
         cubeName : null,
-        timeFilterId : 1,
+        timeFilterId : kylinConfig.getJobTimeFilterId(),
         searchModeId: 2,
         statusIds: []
     };
@@ -33,7 +33,7 @@ KylinApp.service('JobList',function(JobService,$q){
     this.clearJobFilter = function(){
         this.jobFilter = {
           cubeName : null,
-          timeFilterId : 1,
+          timeFilterId : kylinConfig.getJobTimeFilterId(),
           searchModeId: 2,
           statusIds: []
         };
@@ -41,6 +41,7 @@ KylinApp.service('JobList',function(JobService,$q){
 
     this.list = function(jobRequest){
         var defer = $q.defer();
+        console.log();
         JobService.list(jobRequest, function (jobs) {
             angular.forEach(jobs, function (job) {
                 var id = job.uuid;

--- a/webapp/app/js/services/kylinProperties.js
+++ b/webapp/app/js/services/kylinProperties.js
@@ -20,6 +20,7 @@ KylinApp.service('kylinConfig', function (AdminService, $log) {
   var _config;
   var timezone;
   var deployEnv;
+  var jobTimeFilterId;
 
   this.init = function () {
     return AdminService.publicConfig({}, function (config) {
@@ -169,6 +170,15 @@ KylinApp.service('kylinConfig', function (AdminService, $log) {
     }
     return this.sourceType;
   }
+
+  this.getJobTimeFilterId = function() {
+    var jobTimeFilterId = parseInt(this.getProperty("kylin.web.default-time-filter"));
+    if(isNaN(jobTimeFilterId)) {
+      jobTimeFilterId = 2;
+    }
+    return jobTimeFilterId;
+  }
+
   this.getSecurityType = function () {
     this.securityType = this.getProperty("kylin.security.profile").trim();
     return this.securityType;


### PR DESCRIPTION
目前kylin支持的最小 job timeFilter 粒度为 'last one day'，我们在生产环境中,通常是凌晨开始调度任务,执行基于前一天数据的 cube 构建任务，添加当天作业过滤，为我们监控、维护当天任务执行情况带来了便利