### PR TITLE
KYLIN-4152: disable before deleting HBase table

### DIFF
--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/lookup/LookupTableToHFileJob.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/lookup/LookupTableToHFileJob.java
@@ -165,6 +165,8 @@ public class LookupTableToHFileJob extends AbstractHadoopJob {
         extSnapshotInfoManager.removeSnapshot(tableName, lookupSnapshotID);
         String hTableName = snapshotInfo.getStorageLocationIdentifier();
         logger.info("remove related HBase table:{} for snapshot:{}", hTableName, lookupSnapshotID);
+        if(admin.isTableEnabled(TableName.valueOf(hTableName)))
+            admin.disableTable(TableName.valueOf(hTableName));
         HBaseConnection.deleteTable(kylinConfig.getStorageUrl(), hTableName);
     }
 


### PR DESCRIPTION
It should disable hbase table before deleting hbase table. Otherwise it will cause exception.