### PR TITLE
Fix admin service test error 

### DIFF
--- a/server/src/test/java/org/apache/kylin/rest/service/AdminServiceTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/service/AdminServiceTest.java
@@ -72,6 +72,7 @@ public class AdminServiceTest extends ServiceTestBase {
                     "kylin.web.hive-limit=20\n" +
                     "kylin.engine.default=2\n" +
                     "kylin.web.help.3=onboard|Cube Design Tutorial|http://kylin.apache.org/docs/howto/howto_optimize_cubes.html\n" +
+                    "kylin.web.default-time-filter=1\n" +
                     "kylin.web.help.2=tableau|Tableau Guide|http://kylin.apache.org/docs/tutorial/tableau_91.html\n" +
                     "kylin.web.help.1=odbc|ODBC Driver|http://kylin.apache.org/docs/tutorial/odbc.html\n" +
                     "kylin.web.help.0=start|Getting Started|http://kylin.apache.org/docs/tutorial/kylin_sample.html\n" +


### PR DESCRIPTION
The commit ["Add time filter for current day jobs"](https://github.com/apache/kylin/commit/ebff43a81eeac79429138d2be1ab7a9a0d5f41f3) whose commit id is 
 ebff43a81eeac79429138d2be1ab7a9a0d5f41f3 will cause Test case AdminServiceTest. testGetPublicConfig() error because expected kyiln config is unequal with kylin-default.properties