### PR TITLE
KYLIN-4176 Filter the intermediate tables when loading table metadata from tree

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/service/TableService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/TableService.java
@@ -29,6 +29,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.util.HadoopUtil;
@@ -50,6 +52,7 @@ import org.apache.kylin.engine.spark.SparkExecutable;
 import org.apache.kylin.job.execution.DefaultChainedExecutable;
 import org.apache.kylin.job.execution.ExecutableManager;
 import org.apache.kylin.job.execution.ExecutableState;
+import org.apache.kylin.metadata.MetadataConstants;
 import org.apache.kylin.metadata.TableMetadataManager;
 import org.apache.kylin.metadata.model.ColumnDesc;
 import org.apache.kylin.metadata.model.ISourceAware;
@@ -76,6 +79,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -292,7 +297,14 @@ public class TableService extends BasicService {
     public List<String> getSourceTableNames(String project, String database) throws Exception {
         ISourceMetadataExplorer explr = SourceManager.getInstance(getConfig()).getProjectSource(project)
                 .getSourceMetadataExplorer();
-        return explr.listTables(database);
+        List<String> hiveTableNames = explr.listTables(database);
+        Iterable<String> kylinApplicationTableNames = Iterables.filter(hiveTableNames, new Predicate<String>() {
+            @Override
+            public boolean apply(@Nullable String input) {
+                return input != null && !input.startsWith(MetadataConstants.KYLIN_INTERMEDIATE_PREFIX);
+            }
+        });
+        return Lists.newArrayList(kylinApplicationTableNames);
     }
 
     private TableDescResponse cloneTableDesc(TableDesc table, String prj) {


### PR DESCRIPTION
Load table metadata from tree in 'Data Source' tab, then choose one database, you will find the intermediate tables are also loaded, But intermediate tables are the inner tables, which should not be showed to client, so I filter them in the kylin server.