### PR TITLE
KYLIN-4195 The cube size is 'NaN KB' after purging one cube.

### DIFF
--- a/webapp/app/js/controllers/page.js
+++ b/webapp/app/js/controllers/page.js
@@ -153,6 +153,9 @@ KylinApp.controller('PageCtrl', function ($scope, $q, AccessService, $modal, $lo
 
   // Compute data size so as to auto convert to KB/MB/GB/TB)
   $scope.dataSize = function (data) {
+    if(!data){
+      return '0 KB';
+    }
     var size;
     if (data / 1024 / 1024 / 1024 / 1024 >= 1) {
       size = (data / 1024 / 1024 / 1024 / 1024).toFixed(2) + ' TB';


### PR DESCRIPTION
The reason is that when I perform the purge operation, the size_kb parameter returned by the Kylin server is null.
So we can judge whether the input parameter is null in function dataSize, if data is null, return 0 KB.