### PR TITLE
KYLIN-4208 RT OLAP kylin.stream.node configure optimization support all receiver can have the same config

### DIFF
--- a/stream-core/src/main/java/org/apache/kylin/stream/core/util/NodeUtil.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/util/NodeUtil.java
@@ -23,11 +23,8 @@ import org.apache.kylin.stream.core.model.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.net.UnknownHostException;
-import java.util.Enumeration;
 import java.util.Map;
 
 public class NodeUtil {
@@ -50,7 +47,7 @@ public class NodeUtil {
                 result = Node.from(configNodeStr);
             } catch (IllegalArgumentException e) {
                 //Configuration format：port
-                result = new Node(getLocalHostIp(), Integer.parseInt(configNodeStr));
+                result = new Node(getLocalhostName(), Integer.parseInt(configNodeStr));
             }
         } else {
             result = new Node(getLocalhostName(), defaultPort);
@@ -70,30 +67,6 @@ public class NodeUtil {
             host = "UNKNOWN";
         }
         return host;
-    }
-
-    private static String getLocalHostIp() {
-        String ipStr = null;
-        try {
-            Enumeration<NetworkInterface> allNetInterfaces = NetworkInterface.getNetworkInterfaces();
-            while (allNetInterfaces.hasMoreElements()) {
-                NetworkInterface netInterface = (NetworkInterface) allNetInterfaces.nextElement();
-                Enumeration<InetAddress> addresses = netInterface.getInetAddresses();
-                while (addresses.hasMoreElements()) {
-                    InetAddress ip = (InetAddress) addresses.nextElement();
-                    if (ip != null && ip instanceof Inet4Address && !ip.isLoopbackAddress()
-                            && ip.getHostAddress().indexOf(":") == -1) {
-                        logger.info("local ip address {} ", ip.getHostAddress());
-                        ipStr = ip.getHostAddress();
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.error("Fail to get local ip address", e);
-            ipStr = "UNKNOWN";
-        }
-
-        return ipStr;
     }
 
 }


### PR DESCRIPTION
Support three kylin.stream.node config format, ip:prot or port or not set the config.

- if set ip:port , then kylin will set the config ip and port as the currentNode,

- if set port only, then kylin will get the node ip address and set the node ip and port as the currentNode,

- if not set the config ,then kylin will get the node hostname address and set the hostname and defaultPort(7070) as the currentNode.

issue link: https://issues.apache.org/jira/browse/KYLIN-4208