### PR TITLE
KYLIN-4242: Usage instructions in 'PasswordPlaceholderConfigurer' doesn't work

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/security/PasswordPlaceholderConfigurer.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/security/PasswordPlaceholderConfigurer.java
@@ -82,7 +82,7 @@ public class PasswordPlaceholderConfigurer extends PropertyPlaceholderConfigurer
 
     private static void printUsage() {
         System.out.println(
-                "Usage: java org.apache.kylin.rest.security.PasswordPlaceholderConfigurer <EncryptMethod> <your_password>");
+                "Usage: ${KYLIN_HOME/bin/kylin.sh org.apache.kylin.rest.security.PasswordPlaceholderConfigurer <EncryptMethod> <your_password>");
         System.out.println("EncryptMethod: AES or BCrypt");
     }
 


### PR DESCRIPTION
Usage instructions in 'PasswordPlaceholderConfigurer' doesn't work