### PR TITLE
KYLIN-4240 use kylin SSO without LDAP

### DIFF
--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -98,6 +98,12 @@ function retrieveStartCommand() {
     else
         verbose "kylin.security.profile is set to $spring_profile"
     fi
+    # the number of Spring active profiles can be greater than 1. Additional profiles
+    # can be added by setting kylin.security.additional-profiles
+    additional_security_profiles=`bash ${dir}/get-properties.sh kylin.security.additional-profiles`
+    if [[ "x${additional_security_profiles}" != "x" ]]; then
+        spring_profile="${spring_profile},${additional_security_profiles}"
+    fi
 
     retrieveDependency
 

--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -1901,6 +1901,10 @@ public abstract class KylinConfigBase implements Serializable {
         return getOptional("kylin.security.acl.admin-role", "");
     }
 
+    public boolean createAdminWhenAbsent() {
+        return Boolean.parseBoolean(getOptional("kylin.security.create-admin-when-absent", FALSE));
+    }
+
     // ============================================================================
     // WEB
     // ============================================================================
@@ -1936,7 +1940,7 @@ public abstract class KylinConfigBase implements Serializable {
                 + "kylin.web.contact-mail,kylin.web.help.length,kylin.web.help.0,kylin.web.help.1,kylin.web.help.2,"
                 + "kylin.web.help.3,"
                 + "kylin.web.help,kylin.web.hide-measures,kylin.web.link-streaming-guide,kylin.server.external-acl-provider,"
-                + "kylin.security.profile,"
+                + "kylin.security.profile,kylin.security.additional-profiles,"
                 + "kylin.htrace.show-gui-trace-toggle,kylin.web.export-allow-admin,kylin.web.export-allow-other,"
                 + "kylin.cube.cubeplanner.enabled,kylin.web.dashboard-enabled,kylin.tool.auto-migrate-cube.enabled,"
                 + "kylin.job.scheduler.default,kylin.web.default-time-filter");

--- a/core-job/src/main/java/org/apache/kylin/job/JoinedFormatter.java
+++ b/core-job/src/main/java/org/apache/kylin/job/JoinedFormatter.java
@@ -66,7 +66,7 @@ public class JoinedFormatter {
         String startDate = "";
         String endDate = "";
         String partitionColumnDateFormat = partDesc.getPartitionDateFormat();
-        if (StringUtils.isBlank(partitionColumnDateFormat)) {
+        if (partDesc.getPartitionTimeColumn() == null && partDesc.getPartitionDateColumn() == null) {
             startDate = String.valueOf(startInclusive);
             endDate = String.valueOf(endExclusive);
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,11 @@
         <artifactId>spring-security-saml2-core</artifactId>
         <version>${spring.framework.security.extensions.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-cas</artifactId>
+        <version>${spring.framework.security.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/server-base/pom.xml
+++ b/server-base/pom.xml
@@ -190,6 +190,10 @@
             <groupId>org.springframework.security.extensions</groupId>
             <artifactId>spring-security-saml2-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-cas</artifactId>
+        </dependency>
 
         <!-- spring aop -->
         <dependency>

--- a/server-base/src/main/java/org/apache/kylin/rest/controller/UserController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/UserController.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.metadata.MetadataConstants;
 import org.apache.kylin.rest.constant.Constant;
 import org.apache.kylin.rest.exception.BadRequestException;
@@ -77,8 +78,6 @@ public class UserController extends BasicController {
     private static final Logger logger = LoggerFactory.getLogger(UserController.class);
 
     private static final SimpleGrantedAuthority ALL_USERS_AUTH = new SimpleGrantedAuthority(Constant.GROUP_ALL_USERS);
-
-    private static final String ACTIVE_PROFILES_NAME = "spring.profiles.active";
 
     @Autowired
     @Qualifier("userService")
@@ -134,8 +133,8 @@ public class UserController extends BasicController {
     }
 
     private void checkProfileEditAllowed() {
-        String activeProfiles = System.getProperty(ACTIVE_PROFILES_NAME);
-        if (!"testing".equals(activeProfiles) && !"custom".equals(activeProfiles)) {
+        String securityProfile = KylinConfig.getInstanceFromEnv().getSecurityProfile();
+        if (!"testing".equals(securityProfile) && !"custom".equals(securityProfile)) {
             throw new BadRequestException("Action not allowed!");
         }
     }

--- a/server-base/src/main/java/org/apache/kylin/rest/security/cas/CasUserDetailsService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/security/cas/CasUserDetailsService.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.security.cas;
+
+import org.apache.kylin.common.KylinConfig;
+import org.apache.kylin.rest.security.KylinUserManager;
+import org.apache.kylin.rest.security.ManagedUser;
+import org.jasig.cas.client.authentication.AttributePrincipal;
+import org.jasig.cas.client.validation.Assertion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.cas.userdetails.AbstractCasAssertionUserDetailsService;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An implementation of AbstractCasAssertionUserDetailsService
+ * 
+ * It is used to load/create Kylin user when authenticated by CAS server. Users are created when they are not exists
+ * in Kylin system. Default authorities configured by {@link CasUserDetailsService#defaultAuthorities} are
+ * applied to user during creation.
+ */
+public class CasUserDetailsService extends AbstractCasAssertionUserDetailsService {
+    private static final Logger logger = LoggerFactory.getLogger(CasUserDetailsService.class);
+
+    // a default password that should not exists in user stores.
+    // since encryption is applied to the plain text, a simple value like 'NO_PASSWORD' is okay.
+    private static final String NON_EXISTENT_PASSWORD_VALUE = "NO_PASSWORD";
+
+    private String[] defaultAuthorities = {"ALL_USERS"};
+
+    public void setDefaultAuthorities(String[] defaultAuthorities) {
+        this.defaultAuthorities = defaultAuthorities;
+    }
+
+    @Override
+    protected UserDetails loadUserDetails(Assertion assertion) {
+        if (assertion == null) {
+            throw new CredentialsExpiredException("bad assertion");
+        }
+        ManagedUser user = parseUserDetails(assertion);
+        // create user if not exists
+        KylinUserManager kylinUserManager = KylinUserManager.getInstance(KylinConfig.getInstanceFromEnv());
+        ManagedUser existUser = kylinUserManager.get(user.getUsername());
+        if (existUser == null) {
+            kylinUserManager.update(user);
+        }
+        return kylinUserManager.get(user.getUsername());
+    }
+
+    protected ManagedUser parseUserDetails(Assertion assertion) {
+        AttributePrincipal principal = assertion.getPrincipal();
+        List<GrantedAuthority> grantedAuthorities = Stream.of(defaultAuthorities)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        return new ManagedUser(principal.getName(), NON_EXISTENT_PASSWORD_VALUE, true, grantedAuthorities);
+    }
+}

--- a/server-base/src/main/java/org/apache/kylin/rest/security/saml/SAMLSimpleUserDetailsService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/security/saml/SAMLSimpleUserDetailsService.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.security.saml;
+
+import org.apache.kylin.common.KylinConfig;
+import org.apache.kylin.rest.security.KylinUserManager;
+import org.apache.kylin.rest.security.ManagedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.saml.SAMLCredential;
+
+/**
+ * An simple implementation of SAMLUserDetailsService.
+ * 
+ * It is used to load/create Kylin user when authenticated by SAML IdP. Users are created when they are not exists
+ * in Kylin system. Default authorities configured by {@link SAMLSimpleUserDetailsService#defaultAuthorities} are
+ * applied to user during creation. It differs from the implementation
+ * {@link org.apache.kylin.rest.security.SAMLUserDetailsService} which loads user information
+ * from LDAP.
+ */
+public class SAMLSimpleUserDetailsService implements org.springframework.security.saml.userdetails.SAMLUserDetailsService {
+    private static final Logger logger = LoggerFactory.getLogger(SAMLSimpleUserDetailsService.class);
+
+    private static final String NO_EXISTENCE_PASSWORD = "NO_PASSWORD";
+
+    private String[] defaultAuthorities = {"ALL_USERS"};
+
+    public void setDefaultAuthorities(String[] defaultAuthorities) {
+        this.defaultAuthorities = defaultAuthorities;
+    }
+
+    @Override
+    public Object loadUserBySAML(SAMLCredential samlCredential) throws UsernameNotFoundException {
+        final String userEmail = samlCredential.getAttributeAsString("email");
+        logger.debug("samlCredential.email:" + userEmail);
+        final String userName = userEmail.substring(0, userEmail.indexOf("@"));
+
+        KylinUserManager userManager = KylinUserManager.getInstance(KylinConfig.getInstanceFromEnv());
+        ManagedUser existUser = userManager.get(userName);
+        // create if not exists
+        if (existUser == null) {
+            ManagedUser user = new ManagedUser(userName, NO_EXISTENCE_PASSWORD, true, defaultAuthorities);
+            userManager.update(user);
+        }
+        return userManager.get(userName);
+    }
+}

--- a/server/src/main/resources/applicationContext.xml
+++ b/server/src/main/resources/applicationContext.xml
@@ -87,7 +87,7 @@
     <!-- Cache Config -->
     <cache:annotation-driven/>
 
-    <beans profile="ldap,saml">
+    <beans profile="!testing">
         <bean id="ehcache"
               class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean"
               p:configLocation="classpath:ehcache.xml" p:shared="true"/>

--- a/server/src/main/resources/kylin-security-cas-plugin.xml
+++ b/server/src/main/resources/kylin-security-cas-plugin.xml
@@ -1,0 +1,146 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:scr="http://www.springframework.org/schema/security"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+
+    <beans profile="authn-cas">
+        <context:annotation-config/>
+        <context:component-scan base-package="org.springframework.security.cas"/>
+
+        <!-- public resources -->
+        <scr:http security="none" pattern="/image/**"/>
+        <scr:http security="none" pattern="/css/**"/>
+        <scr:http security="none" pattern="/less/**"/>
+        <scr:http security="none" pattern="/fonts/**"/>
+        <scr:http security="none" pattern="/js/**"/>
+        <scr:http security="none" pattern="/login/**"/>
+        <scr:http security="none" pattern="/routes.json"/>
+
+        <!-- Secured Rest API urls with basic authentication -->
+        <scr:http pattern="/api/**" use-expressions="true" authentication-manager-ref="authenticationManager">
+            <scr:csrf disabled="true"/>
+            <scr:http-basic entry-point-ref="unauthorisedEntryPoint"/>
+            <scr:intercept-url pattern="/api/user/authentication*/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/query/runningQueries" access="hasRole('ROLE_ADMIN')"/>
+            <scr:intercept-url pattern="/api/query/*/stop" access="hasRole('ROLE_ADMIN')"/>
+            <scr:intercept-url pattern="/api/query*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/metadata*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/**/metrics" access="permitAll"/>
+            <scr:intercept-url pattern="/api/cache*/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/cubes/src/tables" access="hasAnyRole('ROLE_ANALYST')"/>
+            <scr:intercept-url pattern="/api/cubes*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/models*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/streaming*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/job*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/admin/public_config" access="permitAll"/>
+            <scr:intercept-url pattern="/api/projects*/*" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/admin*/**" access="hasRole('ROLE_ADMIN')"/>
+            <scr:intercept-url pattern="/api/tables/**/snapshotLocalCache/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/**" access="isAuthenticated()"/>
+
+            <scr:form-login login-page="/login"/>
+            <scr:session-management session-fixation-protection="newSession"/>
+        </scr:http>
+
+        <!-- filter on /cas/** for form login compatibility -->
+        <scr:http pattern="/cas/**" auto-config="true" entry-point-ref="casEntryPoint" use-expressions="false"
+                  authentication-manager-ref="authenticationManager">
+            <scr:csrf disabled="true"/>
+            <scr:intercept-url pattern="/cas/**" access="IS_AUTHENTICATED_FULLY"/>
+            <scr:custom-filter before="CAS_FILTER" ref="casHandleSingleLogoutFilter"/>
+            <scr:custom-filter position="CAS_FILTER" ref="casAuthenticationFilter"/>
+        </scr:http>
+        <scr:http auto-config="true" use-expressions="false" authentication-manager-ref="authenticationManager">
+            <scr:csrf disabled="true"/>
+            <scr:http-basic entry-point-ref="unauthorisedEntryPoint"/>
+            <scr:intercept-url pattern="/**" access="IS_AUTHENTICATED_FULLY"/>
+            <scr:form-login login-page="/login"/>
+            <scr:logout invalidate-session="true" delete-cookies="JSESSIONID" logout-success-url="/login"
+                        logout-url="/j_spring_security_logout"/>
+        </scr:http>
+        
+        <!-- AuthenticationProvider based on username/password authentication -->
+        <bean id="kylinUserAuthProvider" class="org.apache.kylin.rest.security.KylinAuthenticationProvider">
+            <constructor-arg>
+                <bean class="org.springframework.security.authentication.dao.DaoAuthenticationProvider">
+                    <property name="userDetailsService">
+                        <bean class="org.apache.kylin.rest.service.KylinUserService"/>
+                    </property>
+                    <property name="passwordEncoder">
+                        <bean class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"/>
+                    </property>
+                </bean>
+            </constructor-arg>
+        </bean>
+        <!-- AuthenticationProvider based on CAS authentication -->
+        <bean id="casAuthenticationProvider"
+              class="org.springframework.security.cas.authentication.CasAuthenticationProvider">
+            <property name="key" value="changeit"/>
+            <property name="authenticationUserDetailsService" ref="casUserDetailsService"/>
+            <property name="serviceProperties" ref="casServiceProperties"/>
+            <property name="ticketValidator" ref="casValidator"/>
+        </bean>
+        <!-- Default AuthenticationManager which tried in order until one provider return non-null -->
+        <bean id="authenticationManager" class="org.springframework.security.authentication.ProviderManager">
+            <constructor-arg>
+                <list>
+                    <ref bean="casAuthenticationProvider"/>
+                    <ref bean="kylinUserAuthProvider"/>
+                </list>
+            </constructor-arg>
+        </bean>
+        <bean id="casAuthenticationFilter" class="org.springframework.security.cas.web.CasAuthenticationFilter">
+            <property name="serviceProperties" ref="casServiceProperties"/>
+            <property name="authenticationManager" ref="authenticationManager"/>
+            <property name="filterProcessesUrl" value="/cas/service"/>
+        </bean>
+        
+        <!-- CAS Client related beans -->
+        <bean id="casServiceProperties" class="org.springframework.security.cas.ServiceProperties">
+            <property name="artifactParameter" value="${kylin.security.cas.artifact-param:ticket}"/>
+            <property name="serviceParameter" value="${kylin.security.cas.service-param:service}"/>
+            <property name="authenticateAllArtifacts" value="${kylin.security.cas.auth-all-artifact:false}"/>
+            <property name="sendRenew" value="${kylin.security.cas.send-renew:false}"/>
+            <property name="service" value="${kylin.server.url}/cas/service"/>
+        </bean>
+        <bean id="casEntryPoint" class="org.springframework.security.cas.web.CasAuthenticationEntryPoint">
+            <property name="loginUrl" value="${kylin.security.cas.server.login-url}"/>
+            <property name="encodeServiceUrlWithSessionId" value="true"/>
+            <property name="serviceProperties" ref="casServiceProperties"/>
+        </bean>
+        <bean id="casValidator" class="org.jasig.cas.client.validation.Cas20ServiceTicketValidator">
+            <constructor-arg index="0" name="casServerUrlPrefix" value="${kylin.security.cas.server.prefix}"/>
+        </bean>
+        <bean id="casUserDetailsService" class="org.apache.kylin.rest.security.cas.CasUserDetailsService">
+            <property name="defaultAuthorities" value="${kylin.security.cas.default-groups:ALL_USERS}"/>
+        </bean>
+        <!-- handle the CAS server to ends the CAS SSO session, not used -->
+        <bean id="casHandleSingleLogoutFilter" class="org.jasig.cas.client.session.SingleSignOutFilter"/>
+        <!-- logout in Kylin when CAS SSO session ends. redirect to CAS server logout page when accessing /cas/logout -->
+        <bean id="casRequestSingleLogoutFilter"
+              class="org.springframework.security.web.authentication.logout.LogoutFilter">
+            <constructor-arg value="${kylin.security.cas.server.logout-url}"/>
+            <constructor-arg>
+                <bean class="org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler"/>
+            </constructor-arg>
+            <property name="filterProcessesUrl" value="/cas/logout"/>
+        </bean>
+    </beans>
+</beans>

--- a/server/src/main/resources/kylin-security-saml-noldap-plugin.xml
+++ b/server/src/main/resources/kylin-security-saml-noldap-plugin.xml
@@ -1,0 +1,305 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:scr="http://www.springframework.org/schema/security"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+	http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+	http://www.springframework.org/schema/security
+	http://www.springframework.org/schema/security/spring-security-4.2.xsd
+    http://www.springframework.org/schema/context
+    http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <!-- It is nearly the same with the SAML settings in kylinSecurity.xml, except that:
+           1. LDAP authorization components have been removed; 
+           2. SAML filter intercept `/saml/**` only;
+         So that unauthenticated user will not be redirected to SAML IdP. Instead, the `/login` page will show 
+         and user can manually jump to SAML IdP by clicking "SAML Login" button. 
+    -->
+    <beans profile="authn-saml">
+        <!-- Enable auto-wiring -->
+        <context:annotation-config/>
+
+        <!-- Scan for auto-wiring classes in spring saml packages -->
+        <context:component-scan base-package="org.springframework.security.saml"/>
+
+        <!-- Unsecured pages -->
+        <scr:http security="none" pattern="/image/**"/>
+        <scr:http security="none" pattern="/css/**"/>
+        <scr:http security="none" pattern="/less/**"/>
+        <scr:http security="none" pattern="/fonts/**"/>
+        <scr:http security="none" pattern="/js/**"/>
+        <scr:http security="none" pattern="/login/**"/>
+        <scr:http security="none" pattern="/routes.json"/>
+
+        <!-- Secured Rest API urls with LDAP basic authentication -->
+        <scr:http pattern="/api/**" use-expressions="true" authentication-manager-ref="samlAuthenticationManager">
+            <scr:csrf disabled="true"/>
+            <scr:http-basic entry-point-ref="unauthorisedEntryPoint"/>
+
+            <scr:intercept-url pattern="/api/user/authentication*/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/query/runningQueries" access="hasRole('ROLE_ADMIN')"/>
+            <scr:intercept-url pattern="/api/query/*/stop" access="hasRole('ROLE_ADMIN')"/>
+            <scr:intercept-url pattern="/api/query*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/metadata*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/**/metrics" access="permitAll"/>
+            <scr:intercept-url pattern="/api/cache*/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/streaming_coordinator/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/cubes/src/tables" access="hasAnyRole('ROLE_ANALYST')"/>
+            <scr:intercept-url pattern="/api/cubes*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/models*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/streaming*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/job*/**" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/admin/public_config" access="permitAll"/>
+            <scr:intercept-url pattern="/api/projects*/*" access="isAuthenticated()"/>
+            <scr:intercept-url pattern="/api/admin*/**" access="hasRole('ROLE_ADMIN')"/>
+            <scr:intercept-url pattern="/api/tables/**/snapshotLocalCache/**" access="permitAll"/>
+            <scr:intercept-url pattern="/api/**" access="isAuthenticated()"/>
+
+            <scr:form-login login-page="/login"/>
+            <scr:session-management session-fixation-protection="newSession"/>
+        </scr:http>
+        <!-- Secured non-api urls with SAML SSO -->
+        <scr:http pattern="/saml/**" auto-config="false" authentication-manager-ref="samlAuthenticationManager"
+                  entry-point-ref="samlEntryPoint" use-expressions="false">
+            <scr:csrf disabled="true"/>
+            <scr:intercept-url pattern="/saml/**" access="IS_AUTHENTICATED_FULLY"/>
+            <scr:custom-filter before="FIRST" ref="metadataGeneratorFilter"/>
+            <scr:custom-filter after="BASIC_AUTH_FILTER" ref="samlFilter"/>
+        </scr:http>
+        <scr:http auto-config="true" use-expressions="false" authentication-manager-ref="samlAuthenticationManager">
+            <scr:csrf disabled="true"/>
+            <scr:http-basic entry-point-ref="unauthorisedEntryPoint"/>
+            <scr:intercept-url pattern="/**" access="IS_AUTHENTICATED_FULLY"/>
+            <scr:form-login login-page="/login"/>
+            <scr:logout invalidate-session="true" delete-cookies="JSESSIONID" logout-success-url="/login"
+                        logout-url="/j_spring_security_logout"/>
+        </scr:http>
+
+        <!-- Authentication manager -->
+        <bean id="samlUserDetailsService" class="org.apache.kylin.rest.security.saml.SAMLSimpleUserDetailsService">
+            <property name="defaultAuthorities" value="${kylin.security.saml.default-groups:ALL_USERS}"/>
+        </bean>
+        <bean id="samlAuthenticationProvider" class="org.springframework.security.saml.SAMLAuthenticationProvider">
+            <property name="userDetails" ref="samlUserDetailsService"/>
+            <property name="consumer" ref="webSSOProfileConsumer"/>
+            <property name="hokConsumer" ref="hokWebSSOProfileConsumer"/>
+        </bean>
+        <bean id="kylinUserAuthProvider" class="org.apache.kylin.rest.security.KylinAuthenticationProvider">
+            <constructor-arg>
+                <bean class="org.springframework.security.authentication.dao.DaoAuthenticationProvider">
+                    <property name="userDetailsService">
+                        <bean class="org.apache.kylin.rest.service.KylinUserService"/>
+                    </property>
+                    <property name="passwordEncoder">
+                        <bean class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"/>
+                    </property>
+                </bean>
+            </constructor-arg>
+        </bean>
+        <scr:authentication-manager id="samlAuthenticationManager">
+            <scr:authentication-provider ref="samlAuthenticationProvider"/>
+            <scr:authentication-provider ref="kylinUserAuthProvider"/>
+        </scr:authentication-manager>
+
+        <!-- Filters for processing of SAML messages -->
+        <bean id="samlFilter" class="org.springframework.security.web.FilterChainProxy">
+            <scr:filter-chain-map request-matcher="ant">
+                <scr:filter-chain pattern="/saml/login/**" filters="samlEntryPoint"/>
+                <scr:filter-chain pattern="/saml/logout/**" filters="samlLogoutFilter"/>
+                <scr:filter-chain pattern="/saml/metadata/**" filters="metadataGeneratorFilter"/>
+                <scr:filter-chain pattern="/saml/SSO/**" filters="samlSSOProcessingFilter"/>
+                <scr:filter-chain pattern="/saml/SLO/**" filters="samlSLOProcessingFilter"/>
+            </scr:filter-chain-map>
+        </bean>
+
+        <bean id="webSSOProfile" class="org.springframework.security.saml.websso.WebSSOProfileImpl"/>
+        <bean id="webSSOProfileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerImpl">
+            <property name="responseSkew" value="600"/>
+        </bean>
+        <bean id="hokWebSSOProfile" class="org.springframework.security.saml.websso.WebSSOProfileHoKImpl"/>
+        <bean id="hokWebSSOProfileConsumer"
+              class="org.springframework.security.saml.websso.WebSSOProfileConsumerHoKImpl"/>
+        <bean id="ecpWebSSOProfile" class="org.springframework.security.saml.websso.WebSSOProfileECPImpl"/>
+        <bean id="samlSLOProfile" class="org.springframework.security.saml.websso.SingleLogoutProfileImpl">
+            <property name="responseSkew" value="600"/>
+        </bean>
+
+        <bean id="parserPool" class="org.opensaml.xml.parse.StaticBasicParserPool" init-method="initialize">
+            <property name="builderFeatures">
+                <map>
+                    <entry key="http://apache.org/xml/features/dom/defer-node-expansion" value="false"/>
+                </map>
+            </property>
+        </bean>
+        <bean id="parserPoolHolder" class="org.springframework.security.saml.parser.ParserPoolHolder"/>
+        <bean id="velocityEngine" class="org.springframework.security.saml.util.VelocityFactory"
+              factory-method="getEngine"/>
+        <bean id="samlLogger" class="org.springframework.security.saml.log.SAMLDefaultLogger"/>
+        <bean id="keyManager" class="org.springframework.security.saml.key.JKSKeyManager">
+            <constructor-arg value="${kylin.security.saml.keystore-file}"/>
+            <constructor-arg type="java.lang.String" value="changeit"/>
+            <constructor-arg>
+                <map>
+                    <entry key="kylin" value="changeit"/>
+                </map>
+            </constructor-arg>
+            <constructor-arg type="java.lang.String" value="kylin"/>
+        </bean>
+        <bean id="samlBootstrap" class="org.springframework.security.saml.SAMLBootstrap"/>
+
+        <!-- SAML Bindings -->
+        <bean id="samlRedirectBinding" class="org.springframework.security.saml.processor.HTTPRedirectDeflateBinding">
+            <constructor-arg ref="parserPool"/>
+        </bean>
+        <bean id="samlPostBinding" class="org.springframework.security.saml.processor.HTTPPostBinding">
+            <constructor-arg ref="parserPool"/>
+            <constructor-arg ref="velocityEngine"/>
+        </bean>
+        <bean id="samlArtifactBinding"
+              class="org.springframework.security.saml.processor.HTTPArtifactBinding">
+            <constructor-arg ref="parserPool"/>
+            <constructor-arg ref="velocityEngine"/>
+            <constructor-arg>
+                <bean class="org.springframework.security.saml.websso.ArtifactResolutionProfileImpl">
+                    <constructor-arg>
+                        <bean class="org.apache.commons.httpclient.HttpClient">
+                            <constructor-arg>
+                                <bean class="org.apache.commons.httpclient.MultiThreadedHttpConnectionManager"/>
+                            </constructor-arg>
+                        </bean>
+                    </constructor-arg>
+                    <property name="processor">
+                        <bean class="org.springframework.security.saml.processor.SAMLProcessorImpl">
+                            <constructor-arg ref="samlSoapBinding"/>
+                        </bean>
+                    </property>
+                </bean>
+            </constructor-arg>
+        </bean>
+        <bean id="samlSoapBinding"
+              class="org.springframework.security.saml.processor.HTTPSOAP11Binding">
+            <constructor-arg ref="parserPool"/>
+        </bean>
+
+        <bean id="samlPaosBinding"
+              class="org.springframework.security.saml.processor.HTTPPAOS11Binding">
+            <constructor-arg ref="parserPool"/>
+        </bean>
+        <bean id="samlProcessor" class="org.springframework.security.saml.processor.SAMLProcessorImpl">
+            <constructor-arg>
+                <list>
+                    <ref bean="samlRedirectBinding"/>
+                    <ref bean="samlPostBinding"/>
+                    <ref bean="samlSoapBinding"/>
+                    <ref bean="samlPaosBinding"/>
+                </list>
+            </constructor-arg>
+        </bean>
+
+        <!-- SAML metadata -->
+        <bean id="metadataGeneratorFilter" class="org.springframework.security.saml.metadata.MetadataGeneratorFilter">
+            <constructor-arg>
+                <bean class="org.springframework.security.saml.metadata.MetadataGenerator">
+                    <property name="entityBaseURL" value="${kylin.security.saml.metadata-entity-base-url}"/>
+                    <property name="extendedMetadata">
+                        <bean class="org.springframework.security.saml.metadata.ExtendedMetadata">
+                            <property name="signMetadata" value="false"/>
+                            <property name="idpDiscoveryEnabled" value="true"/>
+                        </bean>
+                    </property>
+                </bean>
+            </constructor-arg>
+        </bean>
+        <bean id="metadata"
+              class="org.springframework.security.saml.metadata.CachingMetadataManager">
+            <constructor-arg>
+                <list>
+                    <!-- Example of classpath metadata with Extended Metadata -->
+                    <bean class="org.springframework.security.saml.metadata.ExtendedMetadataDelegate">
+                        <constructor-arg>
+                            <bean class="org.opensaml.saml2.metadata.provider.FilesystemMetadataProvider">
+                                <constructor-arg>
+                                    <value type="java.io.File">${kylin.security.saml.metadata-file}</value>
+                                </constructor-arg>
+                                <property name="parserPool" ref="parserPool"/>
+                            </bean>
+                        </constructor-arg>
+                        <constructor-arg>
+                            <bean class="org.springframework.security.saml.metadata.ExtendedMetadata"/>
+                        </constructor-arg>
+                        <property name="metadataTrustCheck" value="false"/>
+                    </bean>
+                </list>
+            </constructor-arg>
+        </bean>
+
+        <!-- Log in/out -->
+        <bean id="samlContextProvider" class="org.springframework.security.saml.context.SAMLContextProviderLB">
+            <property name="scheme" value="${kylin.security.saml.context-scheme}"/>
+            <property name="serverName" value="${kylin.security.saml.context-server-name}"/>
+            <property name="serverPort" value="${kylin.security.saml.context-server-port}"/>
+            <property name="includeServerPortInRequestURL" value="false"/>
+            <property name="contextPath" value="${kylin.security.saml.context-path}"/>
+        </bean>
+
+        <bean id="samlEntryPoint" class="org.springframework.security.saml.SAMLEntryPoint">
+            <property name="defaultProfileOptions">
+                <bean class="org.springframework.security.saml.websso.WebSSOProfileOptions">
+                    <property name="includeScoping" value="false"/>
+                </bean>
+            </property>
+            <property name="webSSOprofile" ref="webSSOProfile"/>
+            <property name="webSSOprofileHoK" ref="hokWebSSOProfile"/>
+            <property name="webSSOprofileECP" ref="ecpWebSSOProfile"/>
+            <property name="contextProvider" ref="samlContextProvider"/>
+        </bean>
+        <bean id="successLogoutHandler"
+              class="org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler"/>
+        <bean id="logoutHandler"
+              class="org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler">
+            <property name="invalidateHttpSession" value="false"/>
+        </bean>
+
+        <!-- SAML SSO -->
+        <bean id="samlSSOProcessingFilter" class="org.springframework.security.saml.SAMLProcessingFilter">
+            <property name="authenticationManager" ref="samlAuthenticationManager"/>
+            <property name="authenticationSuccessHandler">
+                <bean class="org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler">
+                    <property name="defaultTargetUrl" value="/models"/>
+                </bean>
+            </property>
+            <property name="authenticationFailureHandler">
+                <bean class="org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler">
+                    <property name="useForward" value="true"/>
+                    <property name="defaultFailureUrl" value="/login"/>
+                </bean>
+            </property>
+        </bean>
+
+        <!-- SAML SLO -->
+        <bean id="samlSLOProcessingFilter" class="org.springframework.security.saml.SAMLLogoutProcessingFilter">
+            <constructor-arg index="0" ref="successLogoutHandler"/>
+            <constructor-arg index="1" ref="logoutHandler"/>
+        </bean>
+        <bean id="samlLogoutFilter" class="org.springframework.security.saml.SAMLLogoutFilter">
+            <constructor-arg index="0" ref="successLogoutHandler"/>
+            <constructor-arg index="1" ref="logoutHandler"/>
+            <constructor-arg index="2" ref="logoutHandler"/>
+            <property name="profile" ref="samlSLOProfile"/>
+        </bean>
+    </beans>
+</beans>

--- a/server/src/test/java/org/apache/kylin/rest/service/AdminServiceTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/service/AdminServiceTest.java
@@ -67,6 +67,7 @@ public class AdminServiceTest extends ServiceTestBase {
                     "kylin.web.link-hadoop=\n" +
                     "kylin.web.hide-measures=RAW\n" +
                     "kylin.htrace.show-gui-trace-toggle=false\n" +
+                    "kylin.security.additional-profiles=\n" +
                     "kylin.web.export-allow-admin=true\n" +
                     "kylin.env=QA\n" +
                     "kylin.web.hive-limit=20\n" +

--- a/webapp/app/partials/login.html
+++ b/webapp/app/partials/login.html
@@ -55,6 +55,14 @@
                 <div class="space-4"></div>
               </form>
             </div>
+            <div class="box-footer" ng-if="authn">
+              <div>
+                <a class="btn btn-sm btn-default" ng-click="redirectLoginEntry(authn)" style="width: 100%;">
+                  <i class="ace-icon fa fa-sign-in"></i>
+                  <span class="bigger-110">{{authn.label}}</span>
+                </a>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
KYLIN-4240 use kylin SSO without LDAP. see: https://issues.apache.org/jira/browse/KYLIN-4240

## add additional profile
first we change `kylin.sh` to support multiple profiles (`spring.profiles.active` can accept a list of profiles)
```
additional_security_profiles=`bash ${dir}/get-properties.sh kylin.security.additional-profiles`
if [[ "x${additional_security_profiles}" != "x" ]]; then
    spring_profile="${spring_profile},${additional_security_profiles}"
fi
```
We use `custom` security profile and a additional `authn-cas` profile to enable it.
```
kylin.security.profile=custom
kylin.security.additional-profiles=authn-cas
```

## beans and security settings for CAS
Then we add the CAS security context to the classpath, here we put it in `server/resources/kylin-security-cas-plugin.xml` as a plugin. define the following beans under `authn-cas` profile:
```
<beans profile="authn-cas">
 ...
 <spring-security:http pattern="/cas/**">
  ...
 </spring-security:http>
</beans>
```
in security http settings, the CAS filter only applied on `/cas/**`. see the code for details.

## UI update
In front-end, a button is added to redirect to the CAS server.

![](https://issues.apache.org/jira/secure/attachment/12985571/screenshot.png)

User can now login with either username/password or SSO, and their groups can be managed in the `System` tab.

## Other improvement
- automatically add an admin user if there is none (controlled by `kylin.security.create-admin-when-absent`)
- change to `kylinSecurityProfile()` instead of `spring.profiles.active` to avoid mismatch
- fix ehcache settings for `custom` profile
- SAML without LDAP plugin (see `server/resources/kylin-security-saml-noldap-plugin.xml`)

## Appendix: properties for CAS
```
## Security settings, enable CAS
kylin.security.profile=custom
kylin.security.additional-profiles=authn-cas

## CAS properties
# kylin server url should be set for CAS callback, values should be set properly
kylin.server.url=http://localhost:7070/kylin

# change the cas server 
kylin.security.cas.server.prefix=https://cas.example.com/
kylin.security.cas.server.login-url=https://cas.example.com/login
kylin.security.cas.server.logout-url=https://cas.example.com/logout

# optional properties, default values are listed below
#kylin.security.cas.default-groups=ALL_USERS
#kylin.security.cas.service-param=service
#kylin.security.cas.artifact-param=ticket
```