### PR TITLE
KYLIN-4250 FechRunnner should skip the job to process other jobs instead of throwing exception when the job section metadata is not found

### DIFF
--- a/core-job/src/main/java/org/apache/kylin/job/impl/threadpool/DefaultFetcherRunner.java
+++ b/core-job/src/main/java/org/apache/kylin/job/impl/threadpool/DefaultFetcherRunner.java
@@ -64,7 +64,14 @@ public class DefaultFetcherRunner extends FetcherRunner {
                     continue;
                 }
 
-                final Output outputDigest = getExecutableManager().getOutputDigest(id);
+                final Output outputDigest;
+                try {
+                    outputDigest = getExecutableManager().getOutputDigest(id);
+                } catch (IllegalArgumentException e) {
+                    logger.warn("job " + id + " output digest is null, skip.", e);
+                    nOthers++;
+                    continue;
+                }
                 if ((outputDigest.getState() != ExecutableState.READY)) {
                     // logger.debug("Job id:" + id + " not runnable");
                     jobStateCount(id);
@@ -72,6 +79,11 @@ public class DefaultFetcherRunner extends FetcherRunner {
                 }
 
                 final AbstractExecutable executable = getExecutableManager().getJob(id);
+                if (executable == null) {
+                    logger.info("job " + id + " get job is null, skip.");
+                    nOthers++;
+                    continue;
+                }
                 if (!executable.isReady()) {
                     nOthers++;
                     continue;

--- a/core-job/src/main/java/org/apache/kylin/job/impl/threadpool/PriorityFetcherRunner.java
+++ b/core-job/src/main/java/org/apache/kylin/job/impl/threadpool/PriorityFetcherRunner.java
@@ -97,13 +97,25 @@ public class PriorityFetcherRunner extends FetcherRunner {
                     continue;
                 }
 
-                final Output outputDigest = getExecutableManager().getOutputDigest(id);
+                final Output outputDigest;
+                try {
+                    outputDigest = getExecutableManager().getOutputDigest(id);
+                } catch (IllegalArgumentException e) {
+                    logger.warn("job " + id + " output digest is null, skip.", e);
+                    nOthers++;
+                    continue;
+                }
                 if ((outputDigest.getState() != ExecutableState.READY)) {
                     jobStateCount(id);
                     continue;
                 }
 
                 AbstractExecutable executable = getExecutableManager().getJob(id);
+                if (executable == null) {
+                    logger.info("job " + id + " get job is null, skip.");
+                    nOthers++;
+                    continue;
+                }
                 if (!executable.isReady()) {
                     nOthers++;
                     continue;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KYLIN-4250