### PR TITLE
KYLIN-4254: Export from Insight with CSV format error, when sql contains Chinese

### DIFF
--- a/build/deploy/server.xml
+++ b/build/deploy/server.xml
@@ -74,6 +74,7 @@
                    compressionMinSize="2048"
                    noCompressionUserAgents="gozilla,traviata"
                    compressableMimeType="text/html,text/xml,text/javascript,application/javascript,application/json,text/css,text/plain"
+                   URIEncoding="UTF-8"
         />
         <!-- A "Connector" using the shared thread pool-->
         <!-- Define a SSL HTTP/1.1 Connector on port 8443


### PR DESCRIPTION
1. change the default decoding to 'UTF-8' in tomcat's server.xml