### PR TITLE
KYLIN-4258 Real-time OLAP may return incorrect result for some case

### DIFF
--- a/stream-core/src/main/java/org/apache/kylin/stream/core/query/StreamingDataQueryPlanner.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/query/StreamingDataQueryPlanner.java
@@ -45,10 +45,14 @@ public class StreamingDataQueryPlanner {
     }
 
     public boolean canSkip(long timeStart, long timeEnd) {
+        return canSkip(timeStart, timeEnd, false);
+    }
+
+    public boolean canSkip(long timeStart, long timeEnd, boolean endInclude) {
         if (flatFilter == null) {
             return false;
         }
-        CompareFilterTimeRangeChecker timeRangeChecker = new CompareFilterTimeRangeChecker(timeStart, timeEnd);
+        CompareFilterTimeRangeChecker timeRangeChecker = new CompareFilterTimeRangeChecker(timeStart, timeEnd, endInclude);
         for (TupleFilter andFilter : flatFilter.getChildren()) {
             if (andFilter.getOperator() != FilterOperatorEnum.AND) {
                 throw new IllegalStateException("Filter should be AND instead of " + andFilter);

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStoreFilesSearcher.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStoreFilesSearcher.java
@@ -65,7 +65,7 @@ public class ColumnarSegmentStoreFilesSearcher implements IStreamingGTSearcher {
             FragmentMetaInfo fragmentMetaInfo = fragmentData.getFragmentMetaInfo();
             StreamingDataQueryPlanner queryPlanner = searchContext.getQueryPlanner();
             if (fragmentMetaInfo.hasValidEventTimeRange()
-                    && queryPlanner.canSkip(fragmentMetaInfo.getMinEventTime(), fragmentMetaInfo.getMaxEventTime())) {
+                    && queryPlanner.canSkip(fragmentMetaInfo.getMinEventTime(), fragmentMetaInfo.getMaxEventTime(), true)) {
                 continue;
             }
             queryProfile.incScanFile(fragmentData.getSize());

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/FragmentSearchResult.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/FragmentSearchResult.java
@@ -432,7 +432,12 @@ public class FragmentSearchResult implements IStreamingSearchResult {
 
             public boolean aggregate(RawRecord r) {
                 if (rawDimValues == null) {
-                    rawDimValues = r.getDimensions();
+                    byte[][] tmpDimValues = r.getDimensions();
+                    rawDimValues = new byte[tmpDimValues.length][];
+                    for (int i = 0; i < tmpDimValues.length; i++) {
+                        rawDimValues[i] = new byte[tmpDimValues[i].length];
+                        System.arraycopy(tmpDimValues[i], 0, rawDimValues[i], 0, tmpDimValues[i].length);
+                    }
                 }
                 byte[][] metricsVals = r.getMetrics();
                 for (int i = 0; i < aggrs.length; i++) {

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/compress/NoCompressedColumnReader.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/compress/NoCompressedColumnReader.java
@@ -26,7 +26,6 @@ import org.apache.kylin.stream.core.storage.columnar.ColumnDataReader;
 
 public class NoCompressedColumnReader implements ColumnDataReader {
     private ByteBuffer dataBuffer;
-    private byte[] readBuffer;
     private int colDataStartOffset;
     private int colValLength;
     private int rowCount;
@@ -36,7 +35,6 @@ public class NoCompressedColumnReader implements ColumnDataReader {
         this.colDataStartOffset = colDataStartOffset;
         this.colValLength = colValLength;
         this.rowCount = rowCount;
-        this.readBuffer = new byte[colValLength];
     }
 
     public Iterator<byte[]> iterator() {
@@ -44,6 +42,7 @@ public class NoCompressedColumnReader implements ColumnDataReader {
     }
 
     public byte[] read(int rowNum) {
+        byte[] readBuffer = new byte[colValLength];
         dataBuffer.position(colDataStartOffset + rowNum * colValLength);
         dataBuffer.get(readBuffer);
         return readBuffer;
@@ -68,6 +67,7 @@ public class NoCompressedColumnReader implements ColumnDataReader {
 
         @Override
         public byte[] next() {
+            byte[] readBuffer = new byte[colValLength];
             dataBuffer.get(readBuffer);
             readRowCount++;
             return readBuffer;


### PR DESCRIPTION
1. When real-time query group by minute_start and filter by another column, the aggregate result maybe not correct, the issue has been addressed in KYLIN-4184 , the fix is good, but in  

NoCompressedColumnReader class, the readBuffer bytes is still shared, it is a potential issue, need to be fixed.

2. When filter by a minute_start range, the first minute data may not be correct, it is caused by:https://github.com/apache/kylin/blob/master/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStoreFilesSearcher.java#L68, the fragment's max time is inclusive, but this method's max time is exclusive, that may skip some fragments for the first minute by mistake.

3. Add some UT to cover these two cases.