### PR TITLE
KYLIN-4261 Synchronization performed on java.util.concurrent.ConcurrentMap in AssignmentsCache

### DIFF
--- a/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/assign/AssignmentsCache.java
+++ b/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/assign/AssignmentsCache.java
@@ -52,20 +52,14 @@ public class AssignmentsCache {
     }
 
     public List<ReplicaSet> getReplicaSetsByCube(String cubeName) {
-        if (cubeAssignmentCache.get(cubeName) == null) {
-            synchronized (cubeAssignmentCache) {
-                if (cubeAssignmentCache.get(cubeName) == null) {
-                    List<ReplicaSet> result = Lists.newArrayList();
-
-                    CubeAssignment assignment = metadataStore.getAssignmentsByCube(cubeName);
-                    for (Integer replicaSetID : assignment.getReplicaSetIDs()) {
-                        result.add(metadataStore.getReplicaSet(replicaSetID));
-                    }
-                    cubeAssignmentCache.put(cubeName, result);
-                }
+        return cubeAssignmentCache.computeIfAbsent(cubeName, cube -> {
+            List<ReplicaSet> result = Lists.newArrayList();
+            CubeAssignment assignment = metadataStore.getAssignmentsByCube(cube);
+            for (Integer replicaSetID : assignment.getReplicaSetIDs()) {
+                result.add(metadataStore.getReplicaSet(replicaSetID));
             }
-        }
-        return cubeAssignmentCache.get(cubeName);
+            return result;
+        });
     }
 
     public void clearCubeCache(String cubeName) {


### PR DESCRIPTION
FindBugs report issue "Synchronization performed on java.util.concurrent.ConcurrentMap"
in class org.apache.kylin.stream.coordinator.assign.AssignmentsCache. 
use ConcurrentMap.computeIfAbsent to rewirte the code, logic remain the same.