### PR TITLE
KYLIN-4273 Make cube planner works for real-time streaming job

### DIFF
--- a/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/Coordinator.java
+++ b/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/Coordinator.java
@@ -56,6 +56,7 @@ import org.apache.kylin.cube.CubeManager;
 import org.apache.kylin.cube.CubeSegment;
 import org.apache.kylin.engine.mr.CubingJob;
 import org.apache.kylin.engine.mr.StreamingCubingEngine;
+import org.apache.kylin.job.execution.AbstractExecutable;
 import org.apache.kylin.job.execution.DefaultChainedExecutable;
 import org.apache.kylin.job.execution.ExecutableManager;
 import org.apache.kylin.job.execution.ExecutableState;
@@ -1133,12 +1134,20 @@ public class Coordinator implements CoordinatorClient {
     private List<String> findSegmentsCanBuild(String cubeName) {
         List<String> result = Lists.newArrayList();
         CubeInstance cubeInstance = CubeManager.getInstance(KylinConfig.getInstanceFromEnv()).getCube(cubeName);
+        // in optimization
+        if (isInOptimize(cubeInstance)) {
+            return result;
+        }
+        int allowMaxBuildingSegments = cubeInstance.getConfig().getMaxBuildingSegments();
         CubeSegment latestHistoryReadySegment = cubeInstance.getLatestReadySegment();
         long minSegmentStart = -1;
         if (latestHistoryReadySegment != null) {
             minSegmentStart = latestHistoryReadySegment.getTSRange().end.v;
+        } else {
+            // there is no ready segment, to make cube planner work, only 1 segment can build
+            logger.info("there is no ready segments for cube:{}, so only allow 1 segment build concurrently", cubeName);
+            allowMaxBuildingSegments = 1;
         }
-        int allowMaxBuildingSegments = cubeInstance.getConfig().getMaxBuildingSegments();
 
         CubeAssignment assignments = streamMetadataStore.getAssignmentsByCube(cubeName);
         Set<Integer> cubeAssignedReplicaSets = assignments.getReplicaSetIDs();
@@ -1212,6 +1221,31 @@ public class Coordinator implements CoordinatorClient {
             leftQuota--;
         }
         return result;
+    }
+
+    private boolean isInOptimize(CubeInstance cube) {
+        Segments<CubeSegment> readyPendingSegments = cube.getSegments(SegmentStatusEnum.READY_PENDING);
+        if (readyPendingSegments.size() > 0) {
+            logger.info("The cube {} has READY_PENDING segments {}. It's not allowed for building",
+                cube.getName(), readyPendingSegments);
+            return true;
+        }
+        Segments<CubeSegment> newSegments = cube.getSegments(SegmentStatusEnum.NEW);
+        for (CubeSegment newSegment : newSegments) {
+            String jobId = newSegment.getLastBuildJobID();
+            if (jobId == null) {
+                continue;
+            }
+            AbstractExecutable job = getExecutableManager().getJob(jobId);
+            if (job != null && job instanceof CubingJob) {
+                CubingJob cubingJob = (CubingJob) job;
+                if (CubingJob.CubingJobTypeEnum.OPTIMIZE.toString().equals(cubingJob.getJobType())) {
+                    logger.info("The cube {} is in optimization. It's not allowed to build new segments during optimization.", cube.getName());
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/stream-coordinator/src/test/java/org/apache/kylin/stream/coordinator/coordinate/BuildJobSubmitterTest.java
+++ b/stream-coordinator/src/test/java/org/apache/kylin/stream/coordinator/coordinate/BuildJobSubmitterTest.java
@@ -103,7 +103,7 @@ public class BuildJobSubmitterTest extends StreamingTestBase {
         assertEquals(0, buildJobSubmitter.getCubeCheckList().size());
     }
 
-    void prepareTestCheckSegmentBuidJobFromMetadata() {
+    void prepareTestCheckSegmentBuildJobFromMetadata() {
         CubeSegment cubeSegment = stubCubSegment(SegmentStatusEnum.NEW, 100L, 200L);
         CubeInstance cubeInstance = stubCubeInstance(cubeSegment);
         config = stubKylinConfig();
@@ -124,24 +124,24 @@ public class BuildJobSubmitterTest extends StreamingTestBase {
     }
 
     @Test
-    public void testCheckSegmentBuidJobFromMetadata() {
-        prepareTestCheckSegmentBuidJobFromMetadata();
+    public void testCheckSegmentBuildJobFromMetadata() {
+        prepareTestCheckSegmentBuildJobFromMetadata();
         BuildJobSubmitter buildJobSubmitter = new BuildJobSubmitter(streamingCoordinator);
         buildJobSubmitter.restore();
-        List<String> segmentReadyList = buildJobSubmitter.checkSegmentBuidJobFromMetadata(cubeName2);
+        List<String> segmentReadyList = buildJobSubmitter.checkSegmentBuildJobFromMetadata(cubeName2);
         assertEquals(1, segmentReadyList.size());
 
-        segmentReadyList = buildJobSubmitter.checkSegmentBuidJobFromMetadata(cubeName3);
+        segmentReadyList = buildJobSubmitter.checkSegmentBuildJobFromMetadata(cubeName3);
         assertEquals(1, segmentReadyList.size());
     }
 
     @Test
-    public void testCheckSegmentBuidJobFromMetadata1() {
-        prepareTestCheckSegmentBuidJobFromMetadata();
+    public void testCheckSegmentBuildJobFromMetadata1() {
+        prepareTestCheckSegmentBuildJobFromMetadata();
         BuildJobSubmitter buildJobSubmitter = new BuildJobSubmitter(streamingCoordinator);
         buildJobSubmitter.restore();
 
-        List<String> segmentReadyList = buildJobSubmitter.checkSegmentBuidJobFromMetadata(cubeName4);
+        List<String> segmentReadyList = buildJobSubmitter.checkSegmentBuildJobFromMetadata(cubeName4);
         verify(executableManager, times(1)).resumeJob(eq(mockBuildJob4));
         assertEquals(0, segmentReadyList.size());
     }

--- a/stream-coordinator/src/test/java/org/apache/kylin/stream/coordinator/coordinate/StreamingTestBase.java
+++ b/stream-coordinator/src/test/java/org/apache/kylin/stream/coordinator/coordinate/StreamingTestBase.java
@@ -315,14 +315,23 @@ public class StreamingTestBase extends LocalFileMetadataTestCase {
 
     CubeInstance stubCubeInstance(CubeSegment cubSegment) {
         CubeInstance cubeInstance = mock(CubeInstance.class);
+        CubeSegment readySegment = stubCubSegment(SegmentStatusEnum.READY, 0L, 1L);
         when(cubeInstance.latestCopyForWrite()).thenReturn(cubeInstance);
         @SuppressWarnings("unchecked")
         Segments<CubeSegment> segmentSegments = mock(Segments.class, RETURNS_DEEP_STUBS);
+
+        Segments<CubeSegment> optimizedSegments = mock(Segments.class, RETURNS_DEEP_STUBS);
 
         when(segmentSegments.size()).thenReturn(1);
         when(cubeInstance.getBuildingSegments()).thenReturn(segmentSegments);
         when(cubeInstance.getName()).thenReturn(cubeName1);
         when(cubeInstance.getSegment(anyString(), Matchers.any())).thenReturn(cubSegment);
+
+        when(optimizedSegments.size()).thenReturn(0);
+        when(cubeInstance.getLatestReadySegment()).thenReturn(readySegment);
+        when(cubeInstance.getSegments(SegmentStatusEnum.READY_PENDING)).thenReturn(optimizedSegments);
+        when(cubeInstance.getSegments(SegmentStatusEnum.NEW)).thenReturn(segmentSegments);
+
         return cubeInstance;
     }
 


### PR DESCRIPTION
Make cube planner works for real-time streaming job:

1, when no ready segment is ready for streaming cube, only 1 segment is allow to build, ensure that the 1st phrase cube planner will take effective

2, when there are any optimization job is running, stop new segment building for streaming cube