### PR TITLE
KYLIN-4290: Add file lock to kylin startup script to avoid starting multiple instances on one node

### DIFF
--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -76,6 +76,14 @@ function retrieveStartCommand() {
         fi
     fi
 
+    lockfile=$KYLIN_HOME/LOCK
+    if [ ! -e $lockfile ]; then
+        trap "rm -f $lockfile; exit" INT TERM EXIT
+        touch $lockfile
+    else
+        quit "Kylin is starting, wait for it"
+    fi
+
     source ${dir}/check-env.sh
 
     tomcat_root=${dir}/../tomcat
@@ -146,6 +154,7 @@ if [ "$1" == "start" ]
 then
     retrieveStartCommand
     ${start_command} >> ${KYLIN_HOME}/logs/kylin.out 2>&1 & echo $! > ${KYLIN_HOME}/pid &
+    rm -f $lockfile
 
     echo ""
     echo "A new Kylin instance is started by $USER. To stop it, run 'kylin.sh stop'"
@@ -158,6 +167,7 @@ elif [ "$1" == "run" ]
 then
     retrieveStartCommand
     ${start_command}
+    rm -f $lockfile
 
 # stop command
 elif [ "$1" == "stop" ]


### PR DESCRIPTION
When we restart the Kylin instance, due to the slow start of kylin, some monitoring scripts fail to detect the surviving kylin, and will also start the kylin instance. As a result, there are multiple kylin instances on a node.
By adding a file lock to the startup script (kylin.sh), it is guaranteed that only one kylin instance will be started when concurrent startup on a node.