### PR TITLE
KYLIN-4294: Add http api for metrics

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/MetricsController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/MetricsController.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.controller;
+
+import org.apache.kylin.rest.service.MetricsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping(value = "/jmetrics")
+public class MetricsController extends BasicController{
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsController.class);
+
+    @Autowired
+    private MetricsService metricsService;
+
+    @RequestMapping(value = "", method = RequestMethod.GET, produces = { "application/json" })
+    @ResponseBody
+    public ResponseEntity getAllMetrics() {
+        return this.getMetrics(null);
+    }
+
+    @RequestMapping(value = "/{type}", method = RequestMethod.GET, produces = { "application/json" })
+    @ResponseBody
+    public ResponseEntity getMetrics(@PathVariable String type) {
+
+        String metrics = null;
+        try {
+            metrics = metricsService.getMetrics(type);
+        } catch (IllegalStateException e) {
+            LOG.error("get metrics error, type:{}", type, e);
+            return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            LOG.error("get metrics error, type:{}", type, e);
+            return new ResponseEntity("Internal error", HttpStatus.BAD_REQUEST);
+        }
+
+        return new ResponseEntity(metrics, HttpStatus.OK);
+    }
+}

--- a/server-base/src/main/java/org/apache/kylin/rest/service/MetricsService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/MetricsService.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.service;
+
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.kylin.common.metrics.common.Metrics;
+import org.apache.kylin.common.metrics.common.MetricsFactory;
+import org.apache.kylin.common.metrics.metrics2.CodahaleMetrics;
+import org.apache.kylin.common.util.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+@Service("metricsService")
+public class MetricsService extends BasicService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsService.class);
+
+    public String getMetrics(String type) throws Exception {
+
+        if (!this.getConfig().getQueryMetrics2Enabled()) {
+            throw new IllegalStateException("Please enable query metrics2");
+        }
+
+        Metrics instance = MetricsFactory.getInstance();
+        String metric = null;
+        if (!(instance instanceof CodahaleMetrics)) {
+            throw new IllegalStateException("Please use CodahaleMetrics to collect your metrics");
+        }
+        try {
+            metric = ((CodahaleMetrics) instance).dumpJson();
+            if (StringUtils.isNotBlank(type)) {
+                Map<String, Object> map = JsonUtil.readValue(metric, new TypeReference<Map<String, Object>>() {
+                });
+                metric = String.valueOf(map.get(type));
+            }
+        } catch (Exception e) {
+            LOG.error("Dump metric json error, ", e);
+        }
+        return metric;
+    }
+
+}

--- a/server/src/main/resources/kylinSecurity.xml
+++ b/server/src/main/resources/kylinSecurity.xml
@@ -241,6 +241,7 @@
             <scr:intercept-url pattern="/api/query*/**" access="isAuthenticated()"/>
             <scr:intercept-url pattern="/api/metadata*/**" access="isAuthenticated()"/>
             <scr:intercept-url pattern="/api/**/metrics" access="permitAll"/>
+            <scr:intercept-url pattern="/api/**/jmetrics/**" access="hasRole('ROLE_ADMIN')"/>
             <scr:intercept-url pattern="/api/cache*/**" access="permitAll"/>
             <scr:intercept-url pattern="/api/streaming_coordinator/**" access="permitAll"/>
             <scr:intercept-url pattern="/api/service_discovery/state/is_active_job_node" access="permitAll"/>
@@ -291,6 +292,7 @@
             <scr:intercept-url pattern="/api/query*/**" access="isAuthenticated()"/>
             <scr:intercept-url pattern="/api/metadata*/**" access="isAuthenticated()"/>
             <scr:intercept-url pattern="/api/**/metrics" access="permitAll"/>
+            <scr:intercept-url pattern="/api/**/jmetrics/**" access="hasRole('ROLE_ADMIN')"/>
             <scr:intercept-url pattern="/api/cache*/**" access="permitAll"/>
             <scr:intercept-url pattern="/api/streaming_coordinator/**" access="permitAll"/>
             <scr:intercept-url pattern="/api/cubes/src/tables" access="hasAnyRole('ROLE_ANALYST')"/>

--- a/server/src/test/java/org/apache/kylin/rest/controller/MetricsControllerTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/controller/MetricsControllerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.controller;
+
+import org.apache.kylin.rest.service.ServiceTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class MetricsControllerTest extends ServiceTestBase {
+
+    @Autowired
+    MetricsController metricsController;
+
+    @Test
+    public void testQuery() {
+        System.setProperty("kylin.server.query-metrics2-enabled", "true");
+        ResponseEntity metrics = metricsController.getMetrics(null);
+        Assert.assertEquals(HttpStatus.OK, metrics.getStatusCode());
+        Assert.assertTrue(metrics.getBody() instanceof String);
+    }
+
+}


### PR DESCRIPTION
1.  Expose metrics through http api to facilitate the integration of some external monitoring components, such as tsdb
2. add a python script for tcollector