### PR TITLE
KYLIN-4304 Project list cannot be correctly sorted by 'Create Time'

### DIFF
--- a/webapp/app/js/model/projectConfig.js
+++ b/webapp/app/js/model/projectConfig.js
@@ -21,7 +21,7 @@ KylinApp.constant('projectConfig', {
     {attr: 'name', name: 'Name'},
     {attr: 'owner', name: 'Owner'},
     {attr: 'description', name: 'Description'},
-    {attr: 'create_time', name: 'Create Time'}
+    {attr: 'create_time_utc', name: 'Create Time'}
   ]
 
 });


### PR DESCRIPTION
refer to `/webapp/app/js/filters/filter.js`, projects are sorted by their attribute value. There is a wrong attribute name in `projectConfig.js`.

see [KYLIN-4304](https://issues.apache.org/jira/browse/KYLIN-4304)