### PR TITLE
KYLIN-4311 fix noncompliant interator issue in sonar

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/FIFOIterator.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/FIFOIterator.java
@@ -18,6 +18,7 @@
 package org.apache.kylin.common.util;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 
 /**
@@ -40,6 +41,9 @@ public class FIFOIterator<T> implements Iterator<T> {
 
     @Override
     public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
         return q.poll();
     }
 

--- a/core-common/src/main/java/org/apache/kylin/common/util/ImmutableBitSet.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/ImmutableBitSet.java
@@ -20,6 +20,7 @@ package org.apache.kylin.common.util;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 public class ImmutableBitSet implements Iterable<Integer> {
 
@@ -186,6 +187,9 @@ public class ImmutableBitSet implements Iterable<Integer> {
 
             @Override
             public Integer next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 return arr[index++];
             }
 

--- a/core-metadata/src/main/java/org/apache/kylin/source/datagen/ColumnGenerator.java
+++ b/core-metadata/src/main/java/org/apache/kylin/source/datagen/ColumnGenerator.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.TreeSet;
 
@@ -179,7 +180,7 @@ public class ColumnGenerator {
                 // double
                 return formatNumber(randomDouble());
             } else {
-                throw new IllegalStateException();
+                throw new NoSuchElementException();
             }
         }
 
@@ -224,6 +225,9 @@ public class ColumnGenerator {
 
         @Override
         public String next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
             return "" + (next++);
         }
     }

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/cube/v2/ExpectedSizeIterator.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/cube/v2/ExpectedSizeIterator.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.storage.hbase.cube.v2;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -55,7 +56,7 @@ class ExpectedSizeIterator implements Iterator<byte[]> {
     @Override
     public byte[] next() {
         if (current >= expectedSize) {
-            throw new IllegalStateException("Won't have more data");
+            throw new NoSuchElementException("Won't have more data");
         }
         try {
             current++;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KYLIN-4311

By contract, any implementation of the java.util.Iterator.next() method should throw a NoSuchElementException exception when the iteration has no more elements. Any other behavior when the iteration is done could lead to unexpected behavior for users of this Iterator.

https://sonarcloud.io/project/issues?id=org.apache.kylin%3Akylin&issues=AWExwNw9ikuHJGLsvan_&open=AWExwNw9ikuHJGLsvan_

https://sonarcloud.io/project/issues?id=org.apache.kylin%3Akylin&issues=AWExwNxOikuHJGLsvaoZ&open=AWExwNxOikuHJGLsvaoZ

https://sonarcloud.io/project/issues?id=org.apache.kylin%3Akylin&issues=AWExwOHQikuHJGLsvbDO&open=AWExwOHQikuHJGLsvbDO