### PR TITLE
KYLIN-4295 Instances displayed on Query Node are inconsistent with JobNode

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/ServiceDiscoveryStateController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/ServiceDiscoveryStateController.java
@@ -63,6 +63,8 @@ public class ServiceDiscoveryStateController extends BasicController {
         checkCuratorSchedulerEnabled();
         Set<String> allNodes = new HashSet<>();
         Set<String> queryNodes = new HashSet<>();
+        Set<String> jobNodes = new HashSet<>();
+        Set<String> leaders = new HashSet<>();
 
         // get all nodes and query nodes
         for (String serverWithMode : KylinConfig.getInstanceFromEnv().getRestServersWithMode()) {
@@ -75,19 +77,24 @@ public class ServiceDiscoveryStateController extends BasicController {
             if (mode.equals("query") || mode.equals("all")) {
                 queryNodes.add(server);
             }
+            if (mode.equals("job") || mode.equals("all")) {
+                jobNodes.add(server);
+            }
         }
 
         // Get all selection participants(only job nodes will participate in the election) and selected leaders
         Set<Participant> allParticipants = serviceDiscoveryStateService.getAllParticipants();
-        Set<String> jobNodes = allParticipants.stream() //
-                .map(Participant::getId) //
-                .collect(Collectors.toSet()); //
+        if (!allParticipants.isEmpty()) {
+            jobNodes = allParticipants.stream() //
+                    .map(Participant::getId) //
+                    .collect(Collectors.toSet()); //
 
-        // There should only one leader, if there are more than one leader, means something wrong happened
-        Set<String> leaders = allParticipants.stream() //
-                .filter(Participant::isLeader) //
-                .map(Participant::getId) //
-                .collect(Collectors.toSet()); //
+            // There should only one leader, if there are more than one leader, means something wrong happened
+            leaders = allParticipants.stream() //
+                    .filter(Participant::isLeader) //
+                    .map(Participant::getId) //
+                    .collect(Collectors.toSet()); //
+        }
 
         // Ask for other nodes for its job server state
         // current Kylin only has one active job node
@@ -103,8 +110,8 @@ public class ServiceDiscoveryStateController extends BasicController {
         // 100 means CuratorScheduler
         // This monitor only meaningful to CuratorScheduler
         if (KylinConfig.getInstanceFromEnv().getSchedulerType() != 100) {
-            throw new UnsupportedOperationException("Only meaningful when scheduler is CuratorScheduler, " +
-                    "try set kylin.job.scheduler.default to 100 to enable CuratorScheduler.");
+            throw new UnsupportedOperationException("Only meaningful when scheduler is CuratorScheduler, "
+                    + "try set kylin.job.scheduler.default to 100 to enable CuratorScheduler.");
         }
     }
 

--- a/webapp/app/js/controllers/instances.js
+++ b/webapp/app/js/controllers/instances.js
@@ -54,7 +54,7 @@ KylinApp
       if ($scope.selectedLeaders.indexOf(node) >= 0) {
         return "Job Node (Leader)";
       } else {
-        return "Job Node (Follower)";
+        return "Job Node";
       }
     }
 


### PR DESCRIPTION
Query Node can't get allParticipants because query node no need to run job scheduler, so the jobClient is null.
Job Node:
<img width="1123" alt="图片" src="https://user-images.githubusercontent.com/31064237/71354317-8098e200-25b6-11ea-8b5a-e7471cfe2a98.png">
Query Node:
<img width="1122" alt="图片" src="https://user-images.githubusercontent.com/31064237/71354344-9a3a2980-25b6-11ea-97d4-5443d6d37aaa.png">

We can add instance of the mode  equals ‘job’ or ‘all’ to job node list in query server, but query server can not find which job node is Leader. In order to avoid instance page display a leader as a follower by mistake, just display the Leader of job node as Job Node (Leader), the others display as Job Node.
Job Node:
<img width="1137" alt="图片" src="https://user-images.githubusercontent.com/31064237/71356316-cf497a80-25bc-11ea-8471-6c7b2ff82928.png">
Query Node:
<img width="1120" alt="图片" src="https://user-images.githubusercontent.com/31064237/71356426-251e2280-25bd-11ea-8cd7-10f732c0bca2.png">


