### PR TITLE
Fix release test failure

### DIFF
--- a/build/script/package.sh
+++ b/build/script/package.sh
@@ -77,7 +77,5 @@ git rev-parse HEAD >> build/commit_SHA1
 
 sh build/script/build.sh $@         || { exit 1; }
 sh build/script/download-tomcat.sh  || { exit 1; }
-sh build/script/download-spark.sh   || { exit 1; }
-sh build/script/download-flink.sh   || { exit 1; }
 sh build/script/prepare.sh          || { exit 1; }
 sh build/script/compress.sh         || { exit 1; }


### PR DESCRIPTION
Releast test failure because there is a commit in Flink engine  add `sh build/script/download-spark.sh` to package.sh.
This will delete the dir of jenkins SPARK_HOME and result in 'spark not found'.
From v2.6.1, Kylin have not provide Spark binary anymore. So `sh build/script/download-spark.sh` should be deleted from package.sh.