### PR TITLE
htable current-limiting

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -2400,4 +2400,7 @@ public abstract class KylinConfigBase implements Serializable {
         return Integer.parseInt(getOptional("kylin.tool.health-check.stale-job-threshold-days", "30"));
     }
 
+    public int getHTableQuotaLimit(){
+        return Integer.parseInt(getOptional("kylin.hbase.htable-quota-limit", "10000"));
+    }
 }


### PR DESCRIPTION
For reduce the hbase load, when create htable we set the htable current-limiting and make is configurable. The parameter name for htable current-limiting is kylin.hbase.htable-quota-limit and the default value is 10000