### PR TITLE
delete /execute_output metadata when deleting a job

### DIFF
--- a/core-job/src/main/java/org/apache/kylin/job/dao/ExecutableDao.java
+++ b/core-job/src/main/java/org/apache/kylin/job/dao/ExecutableDao.java
@@ -378,7 +378,10 @@ public class ExecutableDao {
 
     public void deleteJob(String uuid) throws PersistentException {
         try {
-            store.deleteResource(pathOfJob(uuid));
+            String[] paths = new String[] {pathOfJob(uuid), pathOfJobOutput(uuid)};
+            for (String path : paths) {
+                store.deleteResource(path);
+            } 
             executableDigestMap.remove(uuid);
         } catch (IOException e) {
             logger.error("error delete job:" + uuid, e);


### PR DESCRIPTION
delete both /execute and /execute_output metadata when deleting a job