### PR TITLE
delete /execute_output metadata at the same time when deleting a job

### DIFF
--- a/core-job/src/main/java/org/apache/kylin/job/dao/ExecutableDao.java
+++ b/core-job/src/main/java/org/apache/kylin/job/dao/ExecutableDao.java
@@ -378,11 +378,28 @@ public class ExecutableDao {
 
     public void deleteJob(String uuid) throws PersistentException {
         try {
+            ExecutablePO executablePO = getJob(uuid);
             store.deleteResource(pathOfJob(uuid));
             executableDigestMap.remove(uuid);
+            removeJobOutput(executablePO);
         } catch (IOException e) {
             logger.error("error delete job:" + uuid, e);
             throw new PersistentException(e);
+        }
+    }
+
+    private void removeJobOutput(ExecutablePO executablePO) {
+        List<String> toDeletePaths = Lists.newArrayList();
+        try {
+            toDeletePaths.add(pathOfJobOutput(executablePO.getUuid()));
+            for (ExecutablePO task : executablePO.getTasks()) {
+                toDeletePaths.add(pathOfJobOutput(task.getUuid()));
+            }
+            for (String path : toDeletePaths) {
+                store.deleteResource(path);
+            }
+        } catch (Exception e) {
+            logger.warn("error delete job output:" + executablePO.getUuid(), e);
         }
     }
 


### PR DESCRIPTION
delete both /execute and /execute_output metadata when deleting a job.
compress commit #1026 