### PR TITLE
KYLIN-4333 Fix Build Server OOM

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/metrics/metrics2/CodahaleMetrics.java
+++ b/core-common/src/main/java/org/apache/kylin/common/metrics/metrics2/CodahaleMetrics.java
@@ -39,7 +39,6 @@ import org.apache.kylin.common.metrics.common.Metrics;
 import org.apache.kylin.common.metrics.common.MetricsConstant;
 import org.apache.kylin.common.metrics.common.MetricsScope;
 import org.apache.kylin.common.metrics.common.MetricsVariable;
-import org.apache.kylin.common.threadlocal.InternalThreadLocal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +75,7 @@ public class CodahaleMetrics implements Metrics {
     private final Lock metersLock = new ReentrantLock();
     private final Lock histogramLock = new ReentrantLock();
     private final Set<Closeable> reporters = new HashSet<Closeable>();
-    private final InternalThreadLocal<HashMap<String, CodahaleMetricsScope>> threadLocalScopes = new InternalThreadLocal<HashMap<String, CodahaleMetricsScope>>() {
+    private final ThreadLocal<HashMap<String, CodahaleMetricsScope>> threadLocalScopes = new ThreadLocal<HashMap<String, CodahaleMetricsScope>>() {
         @Override
         protected HashMap<String, CodahaleMetricsScope> initialValue() {
             return new HashMap<String, CodahaleMetricsScope>();

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceStore.java
@@ -40,7 +40,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.StorageURL;
-import org.apache.kylin.common.threadlocal.InternalThreadLocal;
 import org.apache.kylin.common.util.ClassUtil;
 import org.apache.kylin.common.util.OptionsHelper;
 import org.slf4j.Logger;
@@ -596,7 +595,7 @@ abstract public class ResourceStore {
 
     // ============================================================================
 
-    InternalThreadLocal<Checkpoint> checkpointing = new InternalThreadLocal<>();
+    ThreadLocal<Checkpoint> checkpointing = new ThreadLocal<>();
 
     public Checkpoint checkpoint() {
         Checkpoint cp = checkpointing.get();

--- a/core-metadata/src/main/java/org/apache/kylin/measure/percentile/PercentileSerializer.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/percentile/PercentileSerializer.java
@@ -20,13 +20,12 @@ package org.apache.kylin.measure.percentile;
 
 import java.nio.ByteBuffer;
 
-import org.apache.kylin.common.threadlocal.InternalThreadLocal;
 import org.apache.kylin.metadata.datatype.DataType;
 import org.apache.kylin.metadata.datatype.DataTypeSerializer;
 
 public class PercentileSerializer extends DataTypeSerializer<PercentileCounter> {
     // be thread-safe and avoid repeated obj creation
-    private transient InternalThreadLocal<PercentileCounter> current = null;
+    private transient ThreadLocal<PercentileCounter> current = null;
 
     private double compression;
 
@@ -56,7 +55,7 @@ public class PercentileSerializer extends DataTypeSerializer<PercentileCounter> 
 
     private PercentileCounter current() {
         if (current == null) {
-            current = new InternalThreadLocal<>();
+            current = new ThreadLocal<>();
         }
 
         PercentileCounter counter = current.get();

--- a/core-metadata/src/main/java/org/apache/kylin/measure/topn/DoubleDeltaSerializer.java
+++ b/core-metadata/src/main/java/org/apache/kylin/measure/topn/DoubleDeltaSerializer.java
@@ -17,8 +17,6 @@
  */
 package org.apache.kylin.measure.topn;
 
-import org.apache.kylin.common.threadlocal.InternalThreadLocal;
-
 import java.nio.ByteBuffer;
 
 /**
@@ -43,7 +41,7 @@ public class DoubleDeltaSerializer implements java.io.Serializable {
     final private int precision;
     final private int multiplier;
 
-    transient InternalThreadLocal<long[]> deltasThreadLocal;
+    transient ThreadLocal<long[]> deltasThreadLocal;
 
     public DoubleDeltaSerializer() {
         this(2);
@@ -114,7 +112,7 @@ public class DoubleDeltaSerializer implements java.io.Serializable {
         len = Math.max(0, len);
 
         if (deltasThreadLocal == null) {
-            deltasThreadLocal = new InternalThreadLocal<>();
+            deltasThreadLocal = new ThreadLocal<>();
         }
 
         long[] deltas = deltasThreadLocal.get();

--- a/core-metadata/src/main/java/org/apache/kylin/metadata/datatype/DataTypeSerializer.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/datatype/DataTypeSerializer.java
@@ -23,7 +23,6 @@ import java.io.ObjectInputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-import org.apache.kylin.common.threadlocal.InternalThreadLocal;
 import org.apache.kylin.common.util.BytesSerializer;
 
 import com.google.common.collect.Maps;
@@ -35,7 +34,7 @@ import com.google.common.collect.Maps;
 abstract public class DataTypeSerializer<T> implements BytesSerializer<T>, java.io.Serializable {
 
     final static Map<String, Class<?>> implementations = Maps.newHashMap();
-    protected transient InternalThreadLocal current = new InternalThreadLocal();
+    protected transient ThreadLocal current = new ThreadLocal();
     static {
         implementations.put("char", StringSerializer.class);
         implementations.put("varchar", StringSerializer.class);
@@ -119,6 +118,6 @@ abstract public class DataTypeSerializer<T> implements BytesSerializer<T>, java.
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        current = new InternalThreadLocal();
+        current = new ThreadLocal();
     }
 }


### PR DESCRIPTION
- issue link :https://issues.apache.org/jira/browse/KYLIN-4333

- Internalthreadlocal is not suitable for creating a large number of instances . Otherwise, memory leakage will occur, leading to frequent full GC and even OOM.
