### PR TITLE
Making uniform position of variable declaration statements

### DIFF
--- a/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/client/HttpCoordinatorClient.java
+++ b/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/client/HttpCoordinatorClient.java
@@ -212,10 +212,10 @@ public class HttpCoordinatorClient implements CoordinatorClient {
     }
 
     private Object postRequest(final String path, final String requestContent) throws IOException {
+        final String url = getBaseUrl() + path;
         CoordinatorResponse response = retryCaller.call(new CoordinatorRetryCallable() {
             @Override
             public CoordinatorResponse call() throws Exception {
-                String url = getBaseUrl() + path;
                 String msg = restService.postRequest(url, requestContent);
                 return JsonUtil.readValue(msg, CoordinatorResponse.class);
             }


### PR DESCRIPTION
This fix is based on similar methods in this repository, as described below.

https://github.com/apache/kylin/blob/f41c6c8198e5cad295e9212c6a0047d83bd54ae2/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/client/HttpCoordinatorClient.java#L226-L236
https://github.com/apache/kylin/blob/f41c6c8198e5cad295e9212c6a0047d83bd54ae2/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/client/HttpCoordinatorClient.java#L238-L248
https://github.com/apache/kylin/blob/f41c6c8198e5cad295e9212c6a0047d83bd54ae2/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/client/HttpCoordinatorClient.java#L250-L260