### PR TITLE
Sonar bugs

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/DecimalUtil.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/DecimalUtil.java
@@ -32,9 +32,10 @@ public class DecimalUtil {
         // There are some values of "long" that cannot be represented as "double".
         // Not so "int". If it isn't a long, go straight to double.
         return number instanceof BigDecimal ? (BigDecimal) number
-                : number instanceof BigInteger ? new BigDecimal((BigInteger) number)
-                        : number instanceof Long ? new BigDecimal(number.longValue())
-                                : new BigDecimal(number.doubleValue());
+                : number instanceof Integer ? new BigDecimal((Integer) number)
+                        : number instanceof BigInteger ? new BigDecimal((BigInteger) number)
+                                : number instanceof Long ? new BigDecimal(number.longValue())
+                                        : BigDecimal.valueOf(number.doubleValue());
     }
 
     public static BigDecimal toBigDecimal(Object o) {

--- a/core-cube/src/main/java/org/apache/kylin/gridtable/GTAggregateScanner.java
+++ b/core-cube/src/main/java/org/apache/kylin/gridtable/GTAggregateScanner.java
@@ -434,8 +434,8 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
                 sumSpilledSize += dump.size();
                 // when spilled data is too much, we can modify it by other strategy.
                 // this means, all spilled data is bigger than half of original spillThreshold.
-                if(sumSpilledSize > spillThreshold) {
-                    for(Dump current : dumps) {
+                if (sumSpilledSize > spillThreshold) {
+                    for (Dump current : dumps) {
                         current.spill();
                     }
                     spillThreshold += sumSpilledSize;
@@ -678,7 +678,7 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
                                 + (dumpedFile == null ? "<null>" : dumpedFile.getAbsolutePath()));
                     }
 
-                    if(spillBuffer == null) {
+                    if (spillBuffer == null) {
                         dis = new DataInputStream(new FileInputStream(dumpedFile));
                     } else {
                         dis = new DataInputStream(new ByteArrayInputStream(spillBuffer));
@@ -698,10 +698,10 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
                                 cursorIdx++;
                                 int keyLen = dis.readInt();
                                 byte[] key = new byte[keyLen];
-                                dis.read(key);
+                                dis.readFully(key);
                                 int valueLen = dis.readInt();
                                 byte[] value = new byte[valueLen];
-                                dis.read(value);
+                                dis.readFully(value);
                                 return new Pair<>(key, value);
                             } catch (Exception e) {
                                 throw new RuntimeException(
@@ -720,7 +720,8 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
             }
 
             public void spill() throws IOException {
-                if(spillBuffer == null) return;
+                if (spillBuffer == null)
+                    return;
                 OutputStream ops = new FileOutputStream(dumpedFile);
                 InputStream ips = new ByteArrayInputStream(spillBuffer);
                 IOUtils.copy(ips, ops);
@@ -729,7 +730,7 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
                 IOUtils.closeQuietly(ops);
 
                 logger.info("Spill buffer to disk, location: {}, size = {}.", dumpedFile.getAbsolutePath(),
-                    dumpedFile.length());
+                        dumpedFile.length());
             }
 
             public int size() {

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary.java
@@ -18,7 +18,6 @@
 
 package org.apache.kylin.dict;
 
-
 import org.apache.kylin.common.util.ClassUtil;
 
 /**
@@ -28,7 +27,6 @@ import org.apache.kylin.common.util.ClassUtil;
 @SuppressWarnings("serial")
 @Deprecated
 public class NumberDictionary<T> extends TrieDictionary<T> {
-
 
     // ============================================================================
 
@@ -48,10 +46,10 @@ public class NumberDictionary<T> extends TrieDictionary<T> {
 
     @Override
     protected void setConverterByName(String converterName) throws Exception {
-        converterName = "org.apache.kylin.dict.Number2BytesConverter";
-        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
-        ((Number2BytesConverter)this.bytesConvert).setMaxDigitsBeforeDecimalPoint(Number2BytesConverter.MAX_DIGITS_BEFORE_DECIMAL_POINT_LEGACY);
+        this.bytesConvert = ClassUtil.forName("org.apache.kylin.dict.Number2BytesConverter", BytesConverter.class).getDeclaredConstructor()
+                .newInstance();
+        ((Number2BytesConverter) this.bytesConvert)
+                .setMaxDigitsBeforeDecimalPoint(Number2BytesConverter.MAX_DIGITS_BEFORE_DECIMAL_POINT_LEGACY);
     }
-
 
 }

--- a/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary2.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/NumberDictionary2.java
@@ -39,8 +39,8 @@ public class NumberDictionary2<T> extends NumberDictionary<T> {
 
     @Override
     protected void setConverterByName(String converterName) throws Exception {
-        converterName = "org.apache.kylin.dict.Number2BytesConverter";
-        this.bytesConvert = ClassUtil.forName(converterName, BytesConverter.class).getDeclaredConstructor().newInstance();
+        this.bytesConvert = ClassUtil.forName("org.apache.kylin.dict.Number2BytesConverter", BytesConverter.class).getDeclaredConstructor()
+                .newInstance();
     }
 
 }

--- a/core-metadata/src/main/java/org/apache/kylin/metadata/tuple/Tuple.java
+++ b/core-metadata/src/main/java/org/apache/kylin/metadata/tuple/Tuple.java
@@ -119,7 +119,7 @@ public class Tuple implements ITuple {
             if (fieldValue instanceof BigDecimal) {
                 fieldValue = normalizeDecimal((BigDecimal) fieldValue);
             } else if (fieldValue instanceof Number) {
-                fieldValue = new BigDecimal(((Number) fieldValue).doubleValue());
+                fieldValue = BigDecimal.valueOf(((Number) fieldValue).doubleValue());
             }
         } else if ("float".equals(dataType) && fieldValue instanceof BigDecimal) {
             fieldValue = ((BigDecimal) fieldValue).floatValue();

--- a/datasource-sdk/src/main/java/org/apache/kylin/sdk/datasource/framework/conv/ConvSqlWriter.java
+++ b/datasource-sdk/src/main/java/org/apache/kylin/sdk/datasource/framework/conv/ConvSqlWriter.java
@@ -217,11 +217,11 @@ public class ConvSqlWriter extends SqlPrettyWriter {
     public void writeWithItem(SqlCall call, SqlWithItem.SqlWithItemOperator sqlWithItemOperator, int leftPrec,
                               int rightPrec) {
         final SqlWithItem withItem = (SqlWithItem) call;
-        leftPrec = sqlWithItemOperator.getLeftPrec();
-        rightPrec = sqlWithItemOperator.getRightPrec();
-        withItem.name.unparse(this, leftPrec, rightPrec);
+        int leftP = sqlWithItemOperator.getLeftPrec();
+        int rightP = sqlWithItemOperator.getRightPrec();
+        withItem.name.unparse(this, leftP, rightP);
         if (withItem.columnList != null) {
-            withItem.columnList.unparse(this, leftPrec, rightPrec);
+            withItem.columnList.unparse(this, leftP, rightP);
         }
         this.keyword("AS");
         Frame frame = this.startList(FrameTypeEnum.WITH_ITEM, "(", ")");

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/CubingJob.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/CubingJob.java
@@ -202,7 +202,6 @@ public class CubingJob extends DefaultChainedExecutable {
         CubeInstance cubeInstance = CubeManager.getInstance(context.getConfig())
                 .getCube(CubingExecutableUtil.getCubeName(this.getParams()));
         final Output output = getManager().getOutput(getId());
-        state = output.getState();
         if (state != ExecutableState.ERROR
                 && !cubeInstance.getDescriptor().getStatusNeedNotify().contains(state.toString())) {
             logger.info("state:" + state + " no need to notify users");

--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/util/PercentileCounterSerializer.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/util/PercentileCounterSerializer.java
@@ -47,7 +47,16 @@ public class PercentileCounterSerializer extends Serializer<PercentileCounter> {
         double quantileRatio = input.readDouble();
         int length = input.readInt();
         byte[] buffer = new byte[length];
-        input.read(buffer);
+
+        int offset = 0;
+        int bytesRead;
+        while ((bytesRead = input.read(buffer, offset, buffer.length - offset)) != -1) {
+            offset += bytesRead;
+            if (offset >= buffer.length) {
+                break;
+            }
+        }
+
         PercentileCounter counter = new PercentileCounter(compression, quantileRatio);
         counter.readRegisters(ByteBuffer.wrap(buffer));
         return counter;

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/cube/v2/coprocessor/endpoint/CubeVisitService.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/cube/v2/coprocessor/endpoint/CubeVisitService.java
@@ -150,8 +150,8 @@ public class CubeVisitService extends CubeVisitProtos.CubeVisitService implement
         private long rowCount;
         private long rowBytes;
 
-        ResourceTrackingCellListIterator(Iterator<List<Cell>> delegate,
-                                         long rowCountLimit, long bytesLimit, long deadline) {
+        ResourceTrackingCellListIterator(Iterator<List<Cell>> delegate, long rowCountLimit, long bytesLimit,
+                long deadline) {
             this.delegate = delegate;
             this.rowCountLimit = rowCountLimit;
             this.bytesLimit = bytesLimit;
@@ -242,12 +242,14 @@ public class CubeVisitService extends CubeVisitProtos.CubeVisitService implement
 
         // if user change kylin.properties on kylin server, need to manually redeploy coprocessor jar to update KylinConfig of Env.
         KylinConfig kylinConfig = KylinConfig.createKylinConfig(request.getKylinProperties());
-        
+
         String queryId = request.hasQueryId() ? request.getQueryId() : "UnknownId";
         logger.info("start query {} in thread {}", queryId, Thread.currentThread().getName());
+
+        RuntimeException shouldThrow = null;
         try (SetAndUnsetThreadLocalConfig autoUnset = KylinConfig.setAndUnsetThreadLocalConfig(kylinConfig);
                 SetThreadName ignored = new SetThreadName("Query %s", queryId)) {
-            
+
             final long serviceStartTime = System.currentTimeMillis();
 
             region = (HRegion) env.getRegion();
@@ -428,9 +430,13 @@ public class CubeVisitService extends CubeVisitProtos.CubeVisitService implement
                 try {
                     region.closeRegionOperation();
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    shouldThrow = new RuntimeException(e);
                 }
             }
+        }
+
+        if (null != shouldThrow) {
+            throw shouldThrow;
         }
     }
 


### PR DESCRIPTION
- Fixed 6 sonar bugs according to the rule: **_Method parameters, caught exceptions and foreach variables' initial values should not be ignored_**

- Fixed 6 sonar bugs according to the rule: **_The value returned from a stream read should be checked_**

- Fixed 5 sonar bugs according to the rule: **_Jump statements should not occur in "finally" blocks_**

- Fixed 4 sonar bugs according to the rule: **_"volatile" variables should not be used with compound operators_**

- Fixed 2 sonar bugs according to the rule: **_"BigDecimal(double)" should not be used_**