### PR TITLE
Fix sonar issues

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/persistence/ExponentialBackoffRetry.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/ExponentialBackoffRetry.java
@@ -101,7 +101,7 @@ public class ExponentialBackoffRetry {
         if (retryCount == 0)
             firstSleepTime = System.currentTimeMillis();
 
-        long ms = baseSleepTimeMs * (1 << retryCount);
+        long ms = baseSleepTimeMs * (1L << retryCount);
 
         if (ms > maxSleepTimeMs)
             ms = maxSleepTimeMs;

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/RootPersistentEntity.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/RootPersistentEntity.java
@@ -19,9 +19,6 @@
 package org.apache.kylin.common.persistence;
 
 import java.io.Serializable;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
 
 import org.apache.commons.lang.time.FastDateFormat;
 import org.apache.kylin.common.KylinVersion;
@@ -46,7 +43,6 @@ abstract public class RootPersistentEntity implements AclEntity, Serializable {
 
     static final String DATE_PATTERN = "yyyy-MM-dd HH:mm:ss z";
     static FastDateFormat format = FastDateFormat.getInstance(DATE_PATTERN);
-    static DateFormat df = new SimpleDateFormat(DATE_PATTERN, Locale.ROOT);
 
     public static String formatTime(long millis) {
         return format.format(millis);

--- a/core-common/src/main/java/org/apache/kylin/common/util/ByteArray.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/ByteArray.java
@@ -165,7 +165,7 @@ public class ByteArray implements Comparable<ByteArray>, Serializable {
     @Override
     public String toString() {
         if (data == null)
-            return null;
+            return "";
         else
             return Bytes.toStringBinary(data, offset, length);
     }

--- a/core-cube/src/main/java/org/apache/kylin/cube/cuboid/algorithm/BPUSCalculator.java
+++ b/core-cube/src/main/java/org/apache/kylin/cube/cuboid/algorithm/BPUSCalculator.java
@@ -120,7 +120,7 @@ public class BPUSCalculator implements BenefitPolicy {
     protected double getCostSaving(long descendant, long cuboid) {
         long cuboidCost = getCuboidCost(cuboid);
         long descendantAggCost = getCuboidAggregationCost(descendant);
-        return descendantAggCost - cuboidCost;
+        return (double) descendantAggCost - cuboidCost;
     }
 
     protected Long getCuboidCost(long cuboid) {

--- a/core-cube/src/main/java/org/apache/kylin/cube/cuboid/algorithm/CuboidStatsUtil.java
+++ b/core-cube/src/main/java/org/apache/kylin/cube/cuboid/algorithm/CuboidStatsUtil.java
@@ -125,7 +125,7 @@ public class CuboidStatsUtil {
                     nEffective++;
                 }
             }
-            
+
             if (nEffective != 0)
                 srcCuboidsStats.put(cuboid, totalEstRowCount / nEffective);
             else
@@ -349,7 +349,7 @@ public class CuboidStatsUtil {
     }
 
     private static double calculateRollupRatio(Pair<Long, Long> rollupStats) {
-        double rollupInputCount = rollupStats.getFirst() + rollupStats.getSecond();
+        double rollupInputCount = (double) rollupStats.getFirst() + rollupStats.getSecond();
         return rollupInputCount == 0 ? 0 : 1.0 * rollupStats.getFirst() / rollupInputCount;
     }
 }

--- a/core-cube/src/main/java/org/apache/kylin/cube/inmemcubing/RecordConsumeBlockingQueueController.java
+++ b/core-cube/src/main/java/org/apache/kylin/cube/inmemcubing/RecordConsumeBlockingQueueController.java
@@ -18,17 +18,19 @@
 
 package org.apache.kylin.cube.inmemcubing;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
 
 public class RecordConsumeBlockingQueueController<T> extends ConsumeBlockingQueueController<T> {
 
     public final InputConverterUnit<T> inputConverterUnit;
 
-    private RecordConsumeBlockingQueueController(InputConverterUnit<T> inputConverterUnit, BlockingQueue<T> input, int batchSize) {
+    private RecordConsumeBlockingQueueController(InputConverterUnit<T> inputConverterUnit, BlockingQueue<T> input,
+            int batchSize) {
         super(input, batchSize);
         this.inputConverterUnit = inputConverterUnit;
     }
-   
+
     private T currentObject = null;
     private volatile boolean ifEnd = false;
 
@@ -59,7 +61,7 @@ public class RecordConsumeBlockingQueueController<T> extends ConsumeBlockingQueu
     @Override
     public T next() {
         if (ifEnd() || currentObject == null)
-            throw new IllegalStateException();
+            throw new NoSuchElementException();
 
         T result = currentObject;
         currentObject = null;
@@ -69,12 +71,14 @@ public class RecordConsumeBlockingQueueController<T> extends ConsumeBlockingQueu
     public boolean ifEnd() {
         return ifEnd;
     }
-    
-    public static <T> RecordConsumeBlockingQueueController<T> getQueueController(InputConverterUnit<T> inputConverterUnit, BlockingQueue<T> input){
+
+    public static <T> RecordConsumeBlockingQueueController<T> getQueueController(
+            InputConverterUnit<T> inputConverterUnit, BlockingQueue<T> input) {
         return new RecordConsumeBlockingQueueController<>(inputConverterUnit, input, DEFAULT_BATCH_SIZE);
     }
-    
-    public static <T> RecordConsumeBlockingQueueController<T> getQueueController(InputConverterUnit<T> inputConverterUnit, BlockingQueue<T> input, int batchSize){
+
+    public static <T> RecordConsumeBlockingQueueController<T> getQueueController(
+            InputConverterUnit<T> inputConverterUnit, BlockingQueue<T> input, int batchSize) {
         return new RecordConsumeBlockingQueueController<>(inputConverterUnit, input, batchSize);
     }
 }

--- a/core-cube/src/main/java/org/apache/kylin/gridtable/GTAggregateScanner.java
+++ b/core-cube/src/main/java/org/apache/kylin/gridtable/GTAggregateScanner.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -704,7 +705,7 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
                                 dis.readFully(value);
                                 return new Pair<>(key, value);
                             } catch (Exception e) {
-                                throw new RuntimeException(
+                                throw new NoSuchElementException(
                                         "Cannot read AggregationCache from dumped file: " + e.getMessage());
                             }
                         }

--- a/core-metadata/src/main/java/org/apache/kylin/dimension/AbstractDateDimEnc.java
+++ b/core-metadata/src/main/java/org/apache/kylin/dimension/AbstractDateDimEnc.java
@@ -41,6 +41,10 @@ public class AbstractDateDimEnc extends DimensionEncoding {
     private int fixedLen;
     private IValueCodec codec;
 
+    //Externalizable classes should have no-arguments constructors
+    public AbstractDateDimEnc() {
+    }
+
     protected AbstractDateDimEnc(int fixedLen, IValueCodec codec) {
         this.fixedLen = fixedLen;
         this.codec = codec;

--- a/core-metadata/src/main/java/org/apache/kylin/source/datagen/ColumnGenerator.java
+++ b/core-metadata/src/main/java/org/apache/kylin/source/datagen/ColumnGenerator.java
@@ -255,8 +255,8 @@ public class ColumnGenerator {
         @Override
         public String next() {
             if (values.isEmpty())
-                return null;
-            
+                throw new NoSuchElementException();
+
             return values.get(rand.nextInt(values.size()));
         }
     }
@@ -318,7 +318,7 @@ public class ColumnGenerator {
             if (input.hasNext()) {
                 r = input.next();
             }
-            
+
             if (rand.nextDouble() < nullPct) {
                 r = nullStr;
             }

--- a/core-metrics/src/main/java/org/apache/kylin/metrics/lib/impl/BlockingReservoir.java
+++ b/core-metrics/src/main/java/org/apache/kylin/metrics/lib/impl/BlockingReservoir.java
@@ -161,9 +161,10 @@ public class BlockingReservoir extends AbstractActiveReservoir {
                     startTime = System.currentTimeMillis();
                     continue;
                 } else if (size() < minReportSize && (System.currentTimeMillis() - startTime < maxReportTime)) {
-                    logger.info("The number of records in the blocking queue is less than {} and " +
-                            "the duration from last reporting is less than {} ms. " +
-                            "Will delay to report!", minReportSize, maxReportTime);
+                    logger.info(
+                            "The number of records in the blocking queue is less than {} and "
+                                    + "the duration from last reporting is less than {} ms. " + "Will delay to report!",
+                            minReportSize, maxReportTime);
                     sleep();
                     continue;
                 }
@@ -177,7 +178,7 @@ public class BlockingReservoir extends AbstractActiveReservoir {
 
         private void sleep() {
             try {
-                Thread.sleep(60 * 1000);
+                Thread.sleep(60 * 1000L);
             } catch (InterruptedException e) {
                 logger.warn("Interrupted during running");
             }

--- a/core-storage/src/main/java/org/apache/kylin/storage/StorageContext.java
+++ b/core-storage/src/main/java/org/apache/kylin/storage/StorageContext.java
@@ -155,7 +155,7 @@ public class StorageContext {
             return;
         }
 
-        long temp = this.getOffset() + this.getLimit();
+        long temp = this.getOffset() + (long) this.getLimit();
 
         if (!isValidPushDownLimit(temp)) {
             logger.warn("Not enabling limit push down because current limit is invalid: " + this.getLimit());

--- a/core-storage/src/main/java/org/apache/kylin/storage/gtrecord/SortedIteratorMergerWithLimit.java
+++ b/core-storage/src/main/java/org/apache/kylin/storage/gtrecord/SortedIteratorMergerWithLimit.java
@@ -21,6 +21,7 @@ package org.apache.kylin.storage.gtrecord;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
 
 import com.google.common.base.Preconditions;
@@ -123,7 +124,7 @@ public class SortedIteratorMergerWithLimit<E extends Cloneable> extends SortedIt
         @Override
         public E next() {
             if (!nextFetched) {
-                throw new IllegalStateException("Should hasNext() before next()");
+                throw new NoSuchElementException("Should hasNext() before next()");
             }
 
             //TODO: remove this check when validated

--- a/core-storage/src/test/java/org/apache/kylin/storage/gtrecord/DictGridTableTest.java
+++ b/core-storage/src/test/java/org/apache/kylin/storage/gtrecord/DictGridTableTest.java
@@ -314,7 +314,7 @@ public class DictGridTableTest extends LocalFileMetadataTestCase {
 
         // note the unEvaluatable column 1 in filter is added to group by
         assertEquals(
-                "GTScanRequest [range=[[null, null]-[null, null]], columns={0, 1, 3}, filterPushDown=AND [UNKNOWN_MODEL:NULL.GT_MOCKUP_TABLE.0 GT [\\x00\\x00\\x01J\\xE5\\xBD\\x5C\\x00], [null], [null]], aggrGroupBy={0, 1}, aggrMetrics={3}, aggrMetricsFuncs=[sum]]",
+                "GTScanRequest [range=[[null, null]-[null, null]], columns={0, 1, 3}, filterPushDown=AND [UNKNOWN_MODEL:NULL.GT_MOCKUP_TABLE.0 GT [\\x00\\x00\\x01J\\xE5\\xBD\\x5C\\x00], [], []], aggrGroupBy={0, 1}, aggrMetrics={3}, aggrMetricsFuncs=[sum]]",
                 req.toString());
 
         doScanAndVerify(table, useDeserializedGTScanRequest(req), "[1421280000000, 20, null, 20, null]",

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/BatchOptimizeJobCheckpointBuilder.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/BatchOptimizeJobCheckpointBuilder.java
@@ -36,7 +36,7 @@ import com.google.common.base.Preconditions;
 
 public class BatchOptimizeJobCheckpointBuilder {
 
-    protected static SimpleDateFormat format = new SimpleDateFormat("z yyyy-MM-dd HH:mm:ss", Locale.ROOT);
+    protected SimpleDateFormat format = new SimpleDateFormat("z yyyy-MM-dd HH:mm:ss", Locale.ROOT);
 
     final protected CubeInstance cube;
     final protected String submitter;

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/ByteArrayWritable.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/ByteArrayWritable.java
@@ -113,7 +113,8 @@ public class ByteArrayWritable implements WritableComparable<ByteArrayWritable> 
      *         negative if left is smaller than right.
      */
     public int compareTo(ByteArrayWritable that) {
-        return WritableComparator.compareBytes(this.data, this.offset, this.length, that.data, that.offset, that.length);
+        return WritableComparator.compareBytes(this.data, this.offset, this.length, that.data, that.offset,
+                that.length);
     }
 
     /**
@@ -122,7 +123,7 @@ public class ByteArrayWritable implements WritableComparable<ByteArrayWritable> 
      * @return Positive if left is bigger than right, 0 if they are equal, and
      *         negative if left is smaller than right.
      */
-    public int compareTo(final byte[] that) {
+    public int compareToByteArray(final byte[] that) {
         return WritableComparator.compareBytes(this.data, this.offset, this.length, that, 0, that.length);
     }
 
@@ -132,7 +133,7 @@ public class ByteArrayWritable implements WritableComparable<ByteArrayWritable> 
     @Override
     public boolean equals(Object other) {
         if (other instanceof byte[]) {
-            return compareTo((byte[]) other) == 0;
+            return compareToByteArray((byte[]) other) == 0;
         }
         if (other instanceof ByteArrayWritable) {
             return compareTo((ByteArrayWritable) other) == 0;

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/streaming/ColumnToRowJob.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/streaming/ColumnToRowJob.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 public class ColumnToRowJob extends AbstractHadoopJob {
     private static final Logger logger = LoggerFactory.getLogger(ColumnToRowJob.class);
-    private static final long DEFAULT_SIZE_PER_REDUCER = 16 * 1024 * 1024;
+    private static final long DEFAULT_SIZE_PER_REDUCER = 16 * 1024 * 1024L;
     private static final int MAX_REDUCERS = 1000;
 
     @Override

--- a/query/src/main/java/org/apache/kylin/query/relnode/OLAPProjectRel.java
+++ b/query/src/main/java/org/apache/kylin/query/relnode/OLAPProjectRel.java
@@ -136,7 +136,7 @@ public class OLAPProjectRel extends Project implements OLAPRel {
     public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
         boolean hasRexOver = RexOver.containsOver(getProjects(), null);
         RelOptCost relOptCost = super.computeSelfCost(planner, mq).multiplyBy(.05)
-                .multiplyBy(getProjects().size() * (hasRexOver ? 50 : 1))
+                .multiplyBy(getProjects().size() * (double) (hasRexOver ? 50 : 1))
                 .plus(planner.getCostFactory().makeCost(0.1 * caseCount, 0, 0));
         return planner.getCostFactory().makeCost(relOptCost.getRows(), 0, 0);
     }

--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -208,7 +208,7 @@ public class QueryController extends BasicController {
         if (runTimeMoreThan == -1) {
             return QueryContextFacade.getAllRunningQueries();
         } else {
-            return QueryContextFacade.getLongRunningQueries(runTimeMoreThan * 1000);
+            return QueryContextFacade.getLongRunningQueries(runTimeMoreThan * 1000L);
         }
     }
 

--- a/server-base/src/main/java/org/apache/kylin/rest/job/KylinHealthCheckJob.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/job/KylinHealthCheckJob.java
@@ -18,7 +18,12 @@
 
 package org.apache.kylin.rest.job;
 
-import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
@@ -47,11 +52,7 @@ import org.apache.kylin.metadata.model.SegmentStatusEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
+import com.google.common.collect.Lists;
 
 public class KylinHealthCheckJob extends AbstractApplication {
     private static final Logger logger = LoggerFactory.getLogger(KylinHealthCheckJob.class);
@@ -288,7 +289,7 @@ public class KylinHealthCheckJob extends AbstractApplication {
             long sizeRecordSize = cube.getInputRecordSizeBytes();
             if (sizeRecordSize > 0) {
                 long cubeDataSize = cube.getSizeKB() * 1024;
-                double expansionRate = cubeDataSize / sizeRecordSize;
+                double expansionRate = (double) cubeDataSize / sizeRecordSize;
                 if (sizeRecordSize > 1L * expansionCheckMinCubeSizeInGb * 1024 * 1024 * 1024) {
                     if (expansionRate > warningExpansionRate) {
                         logger.info("Cube: {} in project: {} with too large expansion rate: {}, cube data size: {}G",

--- a/source-jdbc/src/main/java/org/apache/kylin/source/jdbc/SqlUtil.java
+++ b/source-jdbc/src/main/java/org/apache/kylin/source/jdbc/SqlUtil.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.Random;
+
 import org.apache.kylin.metadata.datatype.DataType;
 import org.apache.kylin.source.hive.DBConnConf;
 import org.slf4j.Logger;
@@ -84,7 +85,7 @@ public class SqlUtil {
                 logger.warn("while use:" + dbconf, e);
                 try {
                     int rt = r.nextInt(10);
-                    Thread.sleep(rt * 1000);
+                    Thread.sleep(rt * 1000L);
                 } catch (InterruptedException e1) {
                     Thread.interrupted();
                 }

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/cube/v2/coprocessor/endpoint/CubeVisitService.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/cube/v2/coprocessor/endpoint/CubeVisitService.java
@@ -26,6 +26,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.ArrayUtils;
@@ -124,7 +125,7 @@ public class CubeVisitService extends CubeVisitProtos.CubeVisitService implement
         public List<Cell> next() {
 
             if (nextOne.size() < 1) {
-                throw new IllegalStateException();
+                throw new NoSuchElementException();
             }
             ret.clear();
             ret.addAll(nextOne);

--- a/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/CubeMigrationCLI.java
+++ b/storage-hbase/src/main/java/org/apache/kylin/storage/hbase/util/CubeMigrationCLI.java
@@ -97,7 +97,8 @@ public class CubeMigrationCLI {
     private static final String ACL_INFO_FAMILY_PARENT_COLUMN = "p";
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        logger.warn("org.apache.kylin.storage.hbase.util.CubeMigrationCLI is deprecated, use org.apache.kylin.tool.CubeMigrationCLI instead");
+        logger.warn(
+                "org.apache.kylin.storage.hbase.util.CubeMigrationCLI is deprecated, use org.apache.kylin.tool.CubeMigrationCLI instead");
 
         if (args.length != 8) {
             usage();
@@ -108,12 +109,22 @@ public class CubeMigrationCLI {
     }
 
     private static void usage() {
-        System.out.println("Usage: CubeMigrationCLI srcKylinConfigUri dstKylinConfigUri cubeName projectName copyAclOrNot purgeOrNot overwriteIfExists realExecute");
-        System.out.println(" srcKylinConfigUri: The KylinConfig of the cube’s source \n" + "dstKylinConfigUri: The KylinConfig of the cube’s new home \n" + "cubeName: the name of cube to be migrated. \n" + "projectName: The target project in the target environment.(Make sure it exist) \n" + "copyAclOrNot: true or false: whether copy cube ACL to target environment. \n" + "purgeOrNot: true or false: whether purge the cube from src server after the migration. \n" + "overwriteIfExists: overwrite cube if it already exists in the target environment. \n" + "realExecute: if false, just print the operations to take, if true, do the real migration. \n");
+        System.out.println(
+                "Usage: CubeMigrationCLI srcKylinConfigUri dstKylinConfigUri cubeName projectName copyAclOrNot purgeOrNot overwriteIfExists realExecute");
+        System.out.println(" srcKylinConfigUri: The KylinConfig of the cube’s source \n"
+                + "dstKylinConfigUri: The KylinConfig of the cube’s new home \n"
+                + "cubeName: the name of cube to be migrated. \n"
+                + "projectName: The target project in the target environment.(Make sure it exist) \n"
+                + "copyAclOrNot: true or false: whether copy cube ACL to target environment. \n"
+                + "purgeOrNot: true or false: whether purge the cube from src server after the migration. \n"
+                + "overwriteIfExists: overwrite cube if it already exists in the target environment. \n"
+                + "realExecute: if false, just print the operations to take, if true, do the real migration. \n");
 
     }
 
-    public static void moveCube(KylinConfig srcCfg, KylinConfig dstCfg, String cubeName, String projectName, String copyAcl, String purgeAndDisable, String overwriteIfExists, String realExecute) throws IOException, InterruptedException {
+    public static void moveCube(KylinConfig srcCfg, KylinConfig dstCfg, String cubeName, String projectName,
+            String copyAcl, String purgeAndDisable, String overwriteIfExists, String realExecute)
+            throws IOException, InterruptedException {
 
         srcConfig = srcCfg;
         srcStore = ResourceStore.getStore(srcConfig);
@@ -163,12 +174,16 @@ public class CubeMigrationCLI {
         }
     }
 
-    public static void moveCube(String srcCfgUri, String dstCfgUri, String cubeName, String projectName, String copyAcl, String purgeAndDisable, String overwriteIfExists, String realExecute) throws IOException, InterruptedException {
+    public static void moveCube(String srcCfgUri, String dstCfgUri, String cubeName, String projectName, String copyAcl,
+            String purgeAndDisable, String overwriteIfExists, String realExecute)
+            throws IOException, InterruptedException {
 
-        moveCube(KylinConfig.createInstanceFromUri(srcCfgUri), KylinConfig.createInstanceFromUri(dstCfgUri), cubeName, projectName, copyAcl, purgeAndDisable, overwriteIfExists, realExecute);
+        moveCube(KylinConfig.createInstanceFromUri(srcCfgUri), KylinConfig.createInstanceFromUri(dstCfgUri), cubeName,
+                projectName, copyAcl, purgeAndDisable, overwriteIfExists, realExecute);
     }
 
-    public static void checkMigrationSuccess(KylinConfig kylinConfig, String cubeName, Boolean ifFix) throws IOException {
+    public static void checkMigrationSuccess(KylinConfig kylinConfig, String cubeName, Boolean ifFix)
+            throws IOException {
         CubeMigrationCheckCLI checkCLI = new CubeMigrationCheckCLI(kylinConfig, ifFix);
         checkCLI.execute(cubeName);
     }
@@ -198,12 +213,14 @@ public class CubeMigrationCLI {
 
     private static void changeHtableHost(CubeInstance cube) {
         for (CubeSegment segment : cube.getSegments()) {
-            operations.add(new Opt(OptType.CHANGE_HTABLE_HOST, new Object[] { segment.getStorageLocationIdentifier() }));
+            operations
+                    .add(new Opt(OptType.CHANGE_HTABLE_HOST, new Object[] { segment.getStorageLocationIdentifier() }));
         }
     }
 
     private static void copyACL(CubeInstance cube, String projectName) {
-        operations.add(new Opt(OptType.COPY_ACL, new Object[] { cube.getUuid(), cube.getDescriptor().getModel().getUuid(), projectName }));
+        operations.add(new Opt(OptType.COPY_ACL,
+                new Object[] { cube.getUuid(), cube.getDescriptor().getModel().getUuid(), projectName }));
     }
 
     private static void copyFilesInMetaStore(CubeInstance cube, String overwriteIfExists) throws IOException {
@@ -213,7 +230,8 @@ public class CubeMigrationCLI {
         listCubeRelatedResources(cube, metaItems, dictAndSnapshot);
 
         if (dstStore.exists(cube.getResourcePath()) && !overwriteIfExists.equalsIgnoreCase("true"))
-            throw new IllegalStateException("The cube named " + cube.getName() + " already exists on target metadata store. Use overwriteIfExists to overwrite it");
+            throw new IllegalStateException("The cube named " + cube.getName()
+                    + " already exists on target metadata store. Use overwriteIfExists to overwrite it");
 
         for (String item : metaItems) {
             operations.add(new Opt(OptType.COPY_FILE_IN_META, new Object[] { item }));
@@ -224,7 +242,8 @@ public class CubeMigrationCLI {
         }
     }
 
-    private static void addCubeAndModelIntoProject(CubeInstance srcCube, String cubeName, String projectName) throws IOException {
+    private static void addCubeAndModelIntoProject(CubeInstance srcCube, String cubeName, String projectName)
+            throws IOException {
         String projectResPath = ProjectInstance.concatResourcePath(projectName);
         if (!dstStore.exists(projectResPath))
             throw new IllegalStateException("The target project " + projectName + "does not exist");
@@ -236,7 +255,8 @@ public class CubeMigrationCLI {
         operations.add(new Opt(OptType.PURGE_AND_DISABLE, new Object[] { cubeName }));
     }
 
-    private static void listCubeRelatedResources(CubeInstance cube, List<String> metaResource, Set<String> dictAndSnapshot) throws IOException {
+    private static void listCubeRelatedResources(CubeInstance cube, List<String> metaResource,
+            Set<String> dictAndSnapshot) throws IOException {
 
         CubeDesc cubeDesc = cube.getDescriptor();
         metaResource.add(cube.getResourcePath());
@@ -443,8 +463,10 @@ public class CubeMigrationCLI {
             Table srcAclHtable = null;
             Table destAclHtable = null;
             try {
-                srcAclHtable = HBaseConnection.get(srcConfig.getStorageUrl()).getTable(TableName.valueOf(srcConfig.getMetadataUrlPrefix() + ACL_TABLE_NAME));
-                destAclHtable = HBaseConnection.get(dstConfig.getStorageUrl()).getTable(TableName.valueOf(dstConfig.getMetadataUrlPrefix() + ACL_TABLE_NAME));
+                srcAclHtable = HBaseConnection.get(srcConfig.getStorageUrl())
+                        .getTable(TableName.valueOf(srcConfig.getMetadataUrlPrefix() + ACL_TABLE_NAME));
+                destAclHtable = HBaseConnection.get(dstConfig.getStorageUrl())
+                        .getTable(TableName.valueOf(dstConfig.getMetadataUrlPrefix() + ACL_TABLE_NAME));
 
                 // cube acl
                 Result result = srcAclHtable.get(new Get(Bytes.toBytes(cubeId)));
@@ -455,8 +477,10 @@ public class CubeMigrationCLI {
                         byte[] value = CellUtil.cloneValue(cell);
 
                         // use the target project uuid as the parent
-                        if (Bytes.toString(family).equals(ACL_INFO_FAMILY) && Bytes.toString(column).equals(ACL_INFO_FAMILY_PARENT_COLUMN)) {
-                            String valueString = "{\"id\":\"" + projUUID + "\",\"type\":\"org.apache.kylin.metadata.project.ProjectInstance\"}";
+                        if (Bytes.toString(family).equals(ACL_INFO_FAMILY)
+                                && Bytes.toString(column).equals(ACL_INFO_FAMILY_PARENT_COLUMN)) {
+                            String valueString = "{\"id\":\"" + projUUID
+                                    + "\",\"type\":\"org.apache.kylin.metadata.project.ProjectInstance\"}";
                             value = Bytes.toBytes(valueString);
                         }
                         Put put = new Put(Bytes.toBytes(cubeId));
@@ -531,7 +555,8 @@ public class CubeMigrationCLI {
             String modelId = (String) opt.params[1];
             Table destAclHtable = null;
             try {
-                destAclHtable = HBaseConnection.get(dstConfig.getStorageUrl()).getTable(TableName.valueOf(dstConfig.getMetadataUrlPrefix() + ACL_TABLE_NAME));
+                destAclHtable = HBaseConnection.get(dstConfig.getStorageUrl())
+                        .getTable(TableName.valueOf(dstConfig.getMetadataUrlPrefix() + ACL_TABLE_NAME));
 
                 destAclHtable.delete(new Delete(Bytes.toBytes(cubeId)));
                 destAclHtable.delete(new Delete(Bytes.toBytes(modelId)));
@@ -572,7 +597,7 @@ public class CubeMigrationCLI {
             if (nRetry > 3) {
                 throw new InterruptedException("Cannot rename folder " + srcPath + " to folder " + dstPath);
             } else {
-                Thread.sleep(sleepTime * nRetry * nRetry);
+                Thread.sleep((long) sleepTime * nRetry * nRetry);
             }
         }
     }

--- a/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/Coordinator.java
+++ b/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/Coordinator.java
@@ -37,10 +37,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
+import javax.annotation.Nullable;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
@@ -68,23 +66,23 @@ import org.apache.kylin.stream.coordinator.assign.Assigner;
 import org.apache.kylin.stream.coordinator.assign.AssignmentUtil;
 import org.apache.kylin.stream.coordinator.assign.AssignmentsCache;
 import org.apache.kylin.stream.coordinator.assign.CubePartitionRoundRobinAssigner;
+import org.apache.kylin.stream.coordinator.assign.DefaultAssigner;
+import org.apache.kylin.stream.coordinator.client.CoordinatorClient;
 import org.apache.kylin.stream.coordinator.exception.ClusterStateException;
-import org.apache.kylin.stream.coordinator.exception.StoreException;
-import org.apache.kylin.stream.coordinator.exception.ClusterStateException.TransactionStep;
 import org.apache.kylin.stream.coordinator.exception.ClusterStateException.ClusterState;
+import org.apache.kylin.stream.coordinator.exception.ClusterStateException.TransactionStep;
 import org.apache.kylin.stream.coordinator.exception.CoordinateException;
 import org.apache.kylin.stream.coordinator.exception.NotLeadCoordinatorException;
-import org.apache.kylin.stream.coordinator.assign.DefaultAssigner;
-import org.apache.kylin.stream.core.consumer.ConsumerStartProtocol;
-import org.apache.kylin.stream.core.model.CubeAssignment;
-import org.apache.kylin.stream.core.model.ReplicaSet;
-import org.apache.kylin.stream.coordinator.client.CoordinatorClient;
+import org.apache.kylin.stream.coordinator.exception.StoreException;
 import org.apache.kylin.stream.core.client.HttpReceiverAdminClient;
 import org.apache.kylin.stream.core.client.ReceiverAdminClient;
+import org.apache.kylin.stream.core.consumer.ConsumerStartProtocol;
 import org.apache.kylin.stream.core.model.AssignRequest;
 import org.apache.kylin.stream.core.model.ConsumerStatsResponse;
+import org.apache.kylin.stream.core.model.CubeAssignment;
 import org.apache.kylin.stream.core.model.Node;
 import org.apache.kylin.stream.core.model.PauseConsumersRequest;
+import org.apache.kylin.stream.core.model.ReplicaSet;
 import org.apache.kylin.stream.core.model.ResumeConsumerRequest;
 import org.apache.kylin.stream.core.model.SegmentBuildState;
 import org.apache.kylin.stream.core.model.StartConsumersRequest;
@@ -97,20 +95,22 @@ import org.apache.kylin.stream.core.source.ISourcePositionHandler;
 import org.apache.kylin.stream.core.source.ISourcePositionHandler.MergeStrategy;
 import org.apache.kylin.stream.core.source.IStreamingSource;
 import org.apache.kylin.stream.core.source.Partition;
-import org.apache.kylin.stream.core.source.StreamingTableSourceInfo;
 import org.apache.kylin.stream.core.source.StreamingSourceFactory;
+import org.apache.kylin.stream.core.source.StreamingTableSourceInfo;
 import org.apache.kylin.stream.core.util.HDFSUtil;
 import org.apache.kylin.stream.core.util.NamedThreadFactory;
 import org.apache.kylin.stream.core.util.NodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
-import javax.annotation.Nullable;
 
 /**
  * <pre>
@@ -1226,8 +1226,8 @@ public class Coordinator implements CoordinatorClient {
     private boolean isInOptimize(CubeInstance cube) {
         Segments<CubeSegment> readyPendingSegments = cube.getSegments(SegmentStatusEnum.READY_PENDING);
         if (readyPendingSegments.size() > 0) {
-            logger.info("The cube {} has READY_PENDING segments {}. It's not allowed for building",
-                cube.getName(), readyPendingSegments);
+            logger.info("The cube {} has READY_PENDING segments {}. It's not allowed for building", cube.getName(),
+                    readyPendingSegments);
             return true;
         }
         Segments<CubeSegment> newSegments = cube.getSegments(SegmentStatusEnum.NEW);
@@ -1240,7 +1240,9 @@ public class Coordinator implements CoordinatorClient {
             if (job != null && job instanceof CubingJob) {
                 CubingJob cubingJob = (CubingJob) job;
                 if (CubingJob.CubingJobTypeEnum.OPTIMIZE.toString().equals(cubingJob.getJobType())) {
-                    logger.info("The cube {} is in optimization. It's not allowed to build new segments during optimization.", cube.getName());
+                    logger.info(
+                            "The cube {} is in optimization. It's not allowed to build new segments during optimization.",
+                            cube.getName());
                     return true;
                 }
             }
@@ -1333,7 +1335,7 @@ public class Coordinator implements CoordinatorClient {
             restoreJobStatusChecker();
             while (true) {
                 try {
-                    Thread.sleep(5 * 60 * 1000);
+                    Thread.sleep(5 * 60 * 1000L);
                 } catch (InterruptedException exception) {
                     Thread.interrupted();
                     break;

--- a/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/coordinate/StreamingCoordinator.java
+++ b/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/coordinate/StreamingCoordinator.java
@@ -146,7 +146,6 @@ public class StreamingCoordinator implements CoordinatorClient {
         clusterStateCheckExecutor.scheduleAtFixedRate(clusterDoctor, 5, 10, TimeUnit.MINUTES);
     }
 
-
     /**
      * Assign the streaming cube to replica sets. Replica sets is calculated by Assigner.
      *
@@ -630,7 +629,7 @@ public class StreamingCoordinator implements CoordinatorClient {
             buildJobSubmitter.restore();
             while (true) {
                 try {
-                    Thread.sleep(5 * 60 * 1000);
+                    Thread.sleep(5 * 60 * 1000L);
                 } catch (InterruptedException exception) {
                     Thread.interrupted();
                     break;

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStore.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/ColumnarSegmentStore.java
@@ -247,7 +247,7 @@ public class ColumnarSegmentStore implements IStreamingSegmentStore {
         List<DataSegmentFragment> result = Lists.newArrayList();
         int originFragmentsNum = allFragments.size();
         int minFragments = config.getStreamingMinFragmentsInSegment();
-        long maxFragmentSize = config.getStreamingMaxFragmentSizeInMb() * 1024 * 1024;
+        long maxFragmentSize = config.getStreamingMaxFragmentSizeInMb() * 1024 * 1024L;
         long toMergeDataSize = 0;
         for (int i = 0; i < originFragmentsNum; i++) {
             DataSegmentFragment fragment = allFragments.get(i);

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/FSInputGeneralColumnDataReader.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/FSInputGeneralColumnDataReader.java
@@ -30,7 +30,7 @@ public class FSInputGeneralColumnDataReader implements ColumnDataReader {
     public FSInputGeneralColumnDataReader(FSDataInputStream fsInputStream, int dataStartOffset, int dataLength)
             throws IOException {
         this.fsInputStream = fsInputStream;
-        fsInputStream.seek(dataStartOffset + dataLength - 4);
+        fsInputStream.seek(dataStartOffset + dataLength - 4L);
         this.numOfVals = fsInputStream.readInt();
         fsInputStream.seek(dataStartOffset);
     }

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/FSInputGeneralColumnDataReader.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/FSInputGeneralColumnDataReader.java
@@ -20,6 +20,7 @@ package org.apache.kylin.stream.core.storage.columnar;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 
@@ -59,7 +60,7 @@ public class FSInputGeneralColumnDataReader implements ColumnDataReader {
                     readRowCount++;
                     return result;
                 } catch (IOException e) {
-                    throw new RuntimeException("error when read data", e);
+                    throw new NoSuchElementException("error when read data");
                 }
             }
 

--- a/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/compress/FSInputLZ4CompressedColumnReader.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/storage/columnar/compress/FSInputLZ4CompressedColumnReader.java
@@ -21,12 +21,13 @@ package org.apache.kylin.stream.core.storage.columnar.compress;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
-
-import net.jpountz.lz4.LZ4Factory;
-import net.jpountz.lz4.LZ4SafeDecompressor;
+import java.util.NoSuchElementException;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.kylin.stream.core.storage.columnar.ColumnDataReader;
+
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4SafeDecompressor;
 
 public class FSInputLZ4CompressedColumnReader implements ColumnDataReader {
     private int rowCount;
@@ -89,7 +90,7 @@ public class FSInputLZ4CompressedColumnReader implements ColumnDataReader {
                 try {
                     loadNextBuffer();
                 } catch (IOException e) {
-                    throw new RuntimeException("error when read data", e);
+                    throw new NoSuchElementException("error when read data");
                 }
             }
             byte[] readBuffer = new byte[valLen];

--- a/stream-receiver/src/main/java/org/apache/kylin/stream/server/ReplicaSetLeaderSelector.java
+++ b/stream-receiver/src/main/java/org/apache/kylin/stream/server/ReplicaSetLeaderSelector.java
@@ -73,7 +73,7 @@ public class ReplicaSetLeaderSelector extends LeaderSelectorListenerAdapter impl
         }
         while (true) {
             try {
-                Thread.sleep(5 * 60 * 1000);
+                Thread.sleep(5 * 60 * 1000L);
             } catch (InterruptedException exception) {
                 Thread.interrupted();
                 break;

--- a/tool/src/main/java/org/apache/kylin/tool/CubeMigrationCLI.java
+++ b/tool/src/main/java/org/apache/kylin/tool/CubeMigrationCLI.java
@@ -201,7 +201,7 @@ public class CubeMigrationCLI extends AbstractApplication {
             showOpts();
         }
     }
-    
+
     public void checkMigrationSuccess(KylinConfig kylinConfig, String cubeName, Boolean ifFix) throws IOException {
         CubeMigrationCheckCLI checkCLI = new CubeMigrationCheckCLI(kylinConfig, ifFix);
         checkCLI.execute(cubeName);
@@ -632,7 +632,7 @@ public class CubeMigrationCLI extends AbstractApplication {
         }
         }
     }
-    
+
     private String renameTableWithinProject(String srcItem) {
         if (dstProject != null && srcItem.contains(ResourceStore.TABLE_RESOURCE_ROOT)) {
             String tableIdentity = TableDesc.parseResourcePath(srcItem).getTable();
@@ -670,7 +670,7 @@ public class CubeMigrationCLI extends AbstractApplication {
             if (nRetry > 3) {
                 throw new InterruptedException("Cannot rename folder " + srcPath + " to folder " + dstPath);
             } else {
-                Thread.sleep(sleepTime * nRetry * nRetry);
+                Thread.sleep((long) sleepTime * nRetry * nRetry);
             }
         }
     }


### PR DESCRIPTION
Fixed 30 sonar issues.
- Fixed 18 issues: Math operands should be cast before assignment
- Fixed 7 issues: Iterator.next() methods should throw NoSuchElementException
- Fixed 1 issue: toString() should not return null
- Fixed 2 issues: Non-thread-safe fields should not be static
- Fixed 1 issue:  compareTo should not be overloaded
- Fixed 1 issue: Externalizable classes should have no-arguments constructors