### PR TITLE
KYLIN-4386 Use LinkedHashMap for a deterministic order

### DIFF
--- a/stream-coordinator/src/test/java/org/apache/kylin/stream/coordinator/CoordinatorTest.java
+++ b/stream-coordinator/src/test/java/org/apache/kylin/stream/coordinator/CoordinatorTest.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -231,7 +232,7 @@ public class CoordinatorTest extends LocalFileMetadataTestCase {
 
         Map<Integer, List<Partition>> preAssignMap = metadataStore.getAssignmentsByCube(cubeName).getAssignments();
 
-        Map<Integer, List<Partition>> newAssignMap = new HashMap<>();
+        Map<Integer, List<Partition>> newAssignMap = new LinkedHashMap<>();
         newAssignMap.put(1, Lists.newArrayList(p1, p2, p3));
         newAssignMap.put(2, Lists.newArrayList(p4, p5));
         newAssignMap.put(3, Lists.newArrayList(p6));
@@ -257,7 +258,7 @@ public class CoordinatorTest extends LocalFileMetadataTestCase {
 
         Map<Integer, List<Partition>> preAssignMap = metadataStore.getAssignmentsByCube(cubeName).getAssignments();
 
-        Map<Integer, List<Partition>> newAssignMap = new HashMap<>();
+        Map<Integer, List<Partition>> newAssignMap = new LinkedHashMap<>();
         newAssignMap.put(1, Lists.newArrayList(p1, p2, p3));
         newAssignMap.put(2, Lists.newArrayList(p4, p5));
         newAssignMap.put(3, Lists.newArrayList(p6));


### PR DESCRIPTION
The background information and a detailed analysis is here: 
https://issues.apache.org/jira/browse/KYLIN-4386

The tests in `org.apache.kylin.stream.coordinator.CoordinatorTest#testReassignFailOnStartNew` and `org.apache.kylin.stream.coordinator.CoordinatorTest#testReassignFailOnStopAndSync` will fail when making assertions due to an order issue.

The fix is to use LinkedHashMap instead of HashMap so that the non-deterministic order when iterating a HashMap is eliminated. It will not affect the performance and can make the tests more stable.