### PR TITLE
KYLIN-4397 Use newLinkedHashMap for deterministic order in AssignmentUtil.java	

### DIFF
--- a/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/assign/AssignmentUtil.java
+++ b/stream-coordinator/src/main/java/org/apache/kylin/stream/coordinator/assign/AssignmentUtil.java
@@ -44,7 +44,7 @@ public class AssignmentUtil {
                 List<Partition> partitions = cubeAssignment.getPartitionsByReplicaSetID(replicaSetID);
                 Map<String, List<Partition>> nodeAssignment = nodeAssignmentsMap.get(replicaSetID);
                 if (nodeAssignment == null) {
-                    nodeAssignment = Maps.newHashMap();
+                    nodeAssignment = Maps.newLinkedHashMap();
                     nodeAssignmentsMap.put(replicaSetID, nodeAssignment);
                 }
                 nodeAssignment.put(cubeName, partitions);


### PR DESCRIPTION
This PR aims to solve the issue here: https://issues.apache.org/jira/browse/KYLIN-4397

The fix is to use `newLinkedHashMap` instead of `newHashMap` when initializing a Map. In this way, the non-deterministic behaviour is eliminated and the test will not suffer from the failure again. The code will be more stable.