### PR TITLE
KYLIN-4423 use spring session to support clustered sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
     <!-- REST Service, ref https://github.com/spring-projects/spring-boot/blob/v1.3.8.RELEASE/spring-boot-dependencies/pom.xml -->
     <spring.boot.version>1.3.8.RELEASE</spring.boot.version>
     <spring.framework.version>4.3.10.RELEASE</spring.framework.version>
+    <spring.framework.session.version>1.3.5.RELEASE</spring.framework.session.version>
     <spring.framework.security.version>4.2.3.RELEASE</spring.framework.security.version>
     <spring.framework.security.extensions.version>1.0.2.RELEASE</spring.framework.security.extensions.version>
     <opensaml.version>2.6.6</opensaml.version>
@@ -964,6 +965,12 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
         <version>${spring.framework.version}</version>
+      </dependency>
+      <!-- Spring Session -->
+      <dependency>
+        <groupId>org.springframework.session</groupId>
+        <artifactId>spring-session</artifactId>
+        <version>${spring.framework.session.version}</version>
       </dependency>
       <!-- Spring Security -->
       <dependency>

--- a/server-base/pom.xml
+++ b/server-base/pom.xml
@@ -177,6 +177,12 @@
             <artifactId>spring-test</artifactId>
         </dependency>
 
+        <!-- Spring Session -->
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session</artifactId>
+        </dependency>
+
         <!-- Spring Security -->
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/server-base/src/main/java/org/apache/kylin/rest/session/KylinSessionConfig.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/session/KylinSessionConfig.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.session;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.security.web.authentication.SpringSessionRememberMeServices;
+import org.springframework.session.web.http.CookieHttpSessionStrategy;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+import org.springframework.session.web.http.HttpSessionStrategy;
+import org.springframework.session.web.http.MultiHttpSessionStrategy;
+import org.springframework.session.web.http.SessionEventHttpSessionListenerAdapter;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSessionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * fine tuning {@link org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration
+ * SpringHttpSessionConfiguration} to use {@link KylinSessionFilter} as session filter to substitute the origin
+ * {@link SessionRepositoryFilter} which throws exception when no external {@link SessionRepository} bean is present.
+ */
+@Configuration
+public class KylinSessionConfig {
+    private CookieHttpSessionStrategy defaultHttpSessionStrategy = new CookieHttpSessionStrategy();
+
+    private boolean usesSpringSessionRememberMeServices;
+
+    private ServletContext servletContext;
+
+    private CookieSerializer cookieSerializer;
+
+    private HttpSessionStrategy httpSessionStrategy = this.defaultHttpSessionStrategy;
+
+    private List<HttpSessionListener> httpSessionListeners = new ArrayList<HttpSessionListener>();
+
+    @PostConstruct
+    public void init() {
+        if (this.cookieSerializer != null) {
+            this.defaultHttpSessionStrategy.setCookieSerializer(this.cookieSerializer);
+        } else if (this.usesSpringSessionRememberMeServices) {
+            DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
+            cookieSerializer.setRememberMeRequestAttribute(
+                    SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
+            this.defaultHttpSessionStrategy.setCookieSerializer(cookieSerializer);
+        }
+    }
+
+    @Bean
+    public SessionEventHttpSessionListenerAdapter sessionEventHttpSessionListenerAdapter() {
+        return new SessionEventHttpSessionListenerAdapter(this.httpSessionListeners);
+    }
+
+    @Bean
+    public <S extends ExpiringSession> SessionRepositoryFilter<? extends ExpiringSession> springSessionRepositoryFilter(
+            @Autowired(required = false) SessionRepository<S> sessionRepository) {
+        SessionRepositoryFilter<S> sessionRepositoryFilter = new KylinSessionFilter<>(sessionRepository);
+        sessionRepositoryFilter.setServletContext(this.servletContext);
+        if (this.httpSessionStrategy instanceof MultiHttpSessionStrategy) {
+            sessionRepositoryFilter.setHttpSessionStrategy((MultiHttpSessionStrategy) this.httpSessionStrategy);
+        } else {
+            sessionRepositoryFilter.setHttpSessionStrategy(this.httpSessionStrategy);
+        }
+        return sessionRepositoryFilter;
+    }
+
+    public void setApplicationContext(ApplicationContext applicationContext)
+            throws BeansException {
+        if (ClassUtils.isPresent("org.springframework.security.web.authentication.RememberMeServices", null)) {
+            this.usesSpringSessionRememberMeServices = !ObjectUtils.isEmpty(
+                    applicationContext.getBeanNamesForType(SpringSessionRememberMeServices.class));
+        }
+    }
+
+    @Autowired(required = false)
+    public void setServletContext(ServletContext servletContext) {
+        this.servletContext = servletContext;
+    }
+
+    @Autowired(required = false)
+    public void setCookieSerializer(CookieSerializer cookieSerializer) {
+        this.cookieSerializer = cookieSerializer;
+    }
+
+    @Autowired(required = false)
+    public void setHttpSessionStrategy(HttpSessionStrategy httpSessionStrategy) {
+        this.httpSessionStrategy = httpSessionStrategy;
+    }
+
+    @Autowired(required = false)
+    public void setHttpSessionListeners(List<HttpSessionListener> listeners) {
+        this.httpSessionListeners = listeners;
+    }
+}

--- a/server-base/src/main/java/org/apache/kylin/rest/session/KylinSessionFilter.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/session/KylinSessionFilter.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.session;
+
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class KylinSessionFilter<S extends ExpiringSession> extends SessionRepositoryFilter<S> {
+
+    private boolean externalSessionRepositoryExists;
+
+    public KylinSessionFilter(SessionRepository<S> sessionRepository) {
+        super(sessionRepository != null ? sessionRepository : new NoopSessionRepository<>());
+        this.externalSessionRepositoryExists = (sessionRepository != null);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (externalSessionRepositoryExists) {
+            super.doFilterInternal(request, response, filterChain);
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    public boolean isExternalSessionRepositoryExists() {
+        return externalSessionRepositoryExists;
+    }
+
+    private static class NoopSessionRepository<ES extends ExpiringSession> implements SessionRepository<ES> {
+        @Override
+        public ES createSession() {
+            return null;
+        }
+
+        @Override
+        public void save(ES session) {
+            // do nothing
+        }
+
+        @Override
+        public ES getSession(String id) {
+            return null;
+        }
+
+        @Override
+        public void delete(String id) {
+            // do nothing
+        }
+    }
+}

--- a/server-base/src/test/java/org/apache/kylin/rest/session/KylinSessionTest.java
+++ b/server-base/src/test/java/org/apache/kylin/rest/session/KylinSessionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.rest.session;
+
+import org.junit.Test;
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.MapSessionRepository;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KylinSessionTest {
+    @Test
+    public void testSessionFilter() {
+        KylinSessionConfig config = new KylinSessionConfig();
+        SessionRepositoryFilter<? extends ExpiringSession> filter = config.springSessionRepositoryFilter(null);
+
+        assertTrue("filter type should be KylinSessionFilter",
+                filter instanceof KylinSessionFilter);
+        assertFalse("filter should has no external repository",
+                ((KylinSessionFilter<?>) filter).isExternalSessionRepositoryExists());
+
+        filter = config.springSessionRepositoryFilter(new MapSessionRepository());
+        assertTrue("filter type should be KylinSessionFilter",
+                filter instanceof KylinSessionFilter);
+        assertTrue("filter should has external repository",
+                ((KylinSessionFilter<?>) filter).isExternalSessionRepositoryExists());
+    }
+}

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -61,7 +61,17 @@
 			org.springframework.security.web.session.HttpSessionEventPublisher
 		</listener-class>
 	</listener>
-	
+
+    <!-- Apply Spring Session Filter before any other Filters -->
+    <filter>
+        <filter-name>springSessionRepositoryFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>springSessionRepositoryFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
 <filter>
    <filter-name>CORS</filter-name>
    <filter-class>com.thetransactioncompany.cors.CORSFilter</filter-class>       


### PR DESCRIPTION
add spring session to manage user sessions, one can define a proper SessionRepository to enable it. for Redis repository, the following dependencies and spring bean can be added:
```
<!-- dependencies with best compatible version, add it to pom.xml -->
<dependency>
    <groupId>org.springframework.data</groupId>
    <artifactId>spring-data-redis</artifactId>
    <version>1.8.6.RELEASE</version>
</dependency>
<dependency>
    <groupId>redis.clients</groupId>
    <artifactId>jedis</artifactId>
    <version>2.9.3</version>
</dependency>

<!-- spring beans to add in applicationContext.xml -->
<bean id="redisConnectionFactory"
      class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory">
    <property name="hostName" value="${kylin.session.redis.host:127.0.0.1}"/>
    <property name="port" value="${kylin.session.redis.port:6379}"/>
</bean>
<bean id="redisSessionRepository"
      class="org.springframework.session.data.redis.RedisOperationsSessionRepository">
    <constructor-arg index="0" ref="redisConnectionFactory"/>
</bean>
```
see also: https://issues.apache.org/jira/browse/KYLIN-4423