### PR TITLE
KYLIN-4424 use static web server to help frontend development

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,7 +10,10 @@
   "devDependencies": {
     "grunt": "~0.4.x",
     "grunt-cli": "~0.1.13",
+    "grunt-connect-proxy": "^0.2.0",
+    "grunt-connect-rewrite": "^0.2.2",
     "grunt-contrib": "~0.7.0",
+    "grunt-contrib-watch": "^1.1.0",
     "grunt-html2js": "~0.1.3",
     "grunt-bump": "0.0.6",
     "grunt-htmlrefs": "~0.4.1",


### PR DESCRIPTION
Add `grunt-contrib-connect` to start a static server and `grunt-contrib-watch` to trigger rebuild on source code changing. Additional middleware to fine tune the static web server:
- grunt-connect-rewrite: solve context root problem
- grunt-connect-proxy: proxy REST API to existing Kylin instance

usage:
```
cd /path/to/kylin/source/root/webapp
grunt devserver
```
a static web server will listen on `localhost:7071`

note:
in Gruntfile.js, proxy is set to `127.0.0.1:7070`. If your Kylin instance is started in docker with default settings, it will be okay. Otherwise, you may need to change the `host:port` to adjust to your environment.