### PR TITLE
KYLIN-4438 fix bug: null password may cause RuntimeException when starting up

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/EncryptUtil.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/EncryptUtil.java
@@ -32,6 +32,9 @@ public class EncryptUtil {
             0x65, 0x79 };
 
     public static String encrypt(String strToEncrypt) {
+        if (strToEncrypt == null) {
+            return null;
+        }
         try {
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
             final SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
@@ -45,6 +48,9 @@ public class EncryptUtil {
     }
 
     public static String decrypt(String strToDecrypt) {
+        if (strToDecrypt == null) {
+            return null;
+        }
         try {
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING");
             final SecretKeySpec secretKey = new SecretKeySpec(key, "AES");

--- a/core-common/src/test/java/org/apache/kylin/common/util/EncryptUtilTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/util/EncryptUtilTest.java
@@ -30,5 +30,11 @@ public class EncryptUtilTest {
         Assert.assertEquals("4stv/RRleOtvie/8SLHmXA==", result);
     }
 
+    @Test
+    public void testNullInput() {
+        Assert.assertNull(EncryptUtil.encrypt(null));
+        Assert.assertNull(EncryptUtil.decrypt(null));
+    }
+
 }
 


### PR DESCRIPTION
## Proposed changes
Add condition to treet null input for EncryptUtil methods.  For default settings, password may not be set, so `null` will passed to `PasswordPlaceholderConfigurer#resolvePlaceholder`.  This will cause an "IllegalArgumentException: Null input buffer" and lead to startup failure. This fix treets `null` as a legal input and returns `null` for both encrytion and decrytion.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-4438), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I will prepare another pr against the `document` branch
- [x] Any dependent changes have been merged

## Further comments
 N/A