### PR TITLE
KYLIN-4432 duplicated queries with sytax error take unexpect long time when lazy query enabled

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/service/QueryService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/QueryService.java
@@ -467,13 +467,14 @@ public class QueryService extends BasicService {
 
         boolean isDummyResponseEnabled = queryCacheEnabled && kylinConfig.isLazyQueryEnabled();
         SQLResponse sqlResponse = null;
-        // Add dummy response which will be updated or evicted when query finishes
-        if (isDummyResponseEnabled) {
-            SQLResponse dummyResponse = new SQLResponse();
-            dummyResponse.setLazyQueryStartTime(System.currentTimeMillis());
-            cacheManager.getCache(QUERY_CACHE).put(sqlRequest.getCacheKey(), dummyResponse);
-        }
         try {
+            // Add dummy response which will be updated or evicted when query finishes
+            if (isDummyResponseEnabled) {
+                SQLResponse dummyResponse = new SQLResponse();
+                dummyResponse.setLazyQueryStartTime(System.currentTimeMillis());
+                cacheManager.getCache(QUERY_CACHE).put(sqlRequest.getCacheKey(), dummyResponse);
+            }
+
             final boolean isSelect = QueryUtil.isSelectStatement(sqlRequest.getSql());
             if (isSelect) {
                 sqlResponse = query(sqlRequest, queryContext.getQueryId());
@@ -548,14 +549,10 @@ public class QueryService extends BasicService {
                     && ExceptionUtils.getRootCause(e) instanceof ResourceLimitExceededException) {
                 Cache exceptionCache = cacheManager.getCache(QUERY_CACHE);
                 exceptionCache.put(sqlRequest.getCacheKey(), sqlResponse);
-            }
-        } finally {
-            if (isDummyResponseEnabled) {
-                Cache queryCache = cacheManager.getCache(QUERY_CACHE);
-                Cache.ValueWrapper v = queryCache.get(sqlRequest.getCacheKey());
-                if (v != null && v.get() instanceof SQLResponse && ((SQLResponse) v.get()).isRunning()) {
-                    queryCache.evict(sqlRequest.getCacheKey());
-                }
+            } else if (isDummyResponseEnabled) {
+                // evict dummy response to avoid caching too many bad queries
+                Cache exceptionCache = cacheManager.getCache(QUERY_CACHE);
+                exceptionCache.evict(sqlRequest.getCacheKey());
             }
         }
         return sqlResponse;

--- a/server/src/test/java/org/apache/kylin/rest/service/QueryServiceTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/service/QueryServiceTest.java
@@ -47,7 +47,7 @@ public class QueryServiceTest extends ServiceTestBase {
     QueryService queryService;
 
     @Autowired
-    protected CacheManager cacheManager;
+    CacheManager cacheManager;
 
     @Test
     public void testBasics() throws JobException, IOException, SQLException {

--- a/server/src/test/java/org/apache/kylin/rest/service/QueryServiceTest.java
+++ b/server/src/test/java/org/apache/kylin/rest/service/QueryServiceTest.java
@@ -34,6 +34,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
 /**
  * @author xduo
@@ -45,8 +47,7 @@ public class QueryServiceTest extends ServiceTestBase {
     QueryService queryService;
 
     @Autowired
-    @Qualifier("cacheService")
-    private CacheService cacheService;
+    protected CacheManager cacheManager;
 
     @Test
     public void testBasics() throws JobException, IOException, SQLException {
@@ -96,6 +97,27 @@ public class QueryServiceTest extends ServiceTestBase {
             Assert.assertEquals(
                     "WITH tableId as (select * from some_table1) , tableId2 AS (select * FROM some_table2) select * from tableId join tableId2 on tableId.a = tableId2.b;",
                     response.getExceptionMessage());
+        }
+    }
+
+    @Test
+    public void testSyntaxError() {
+        KylinConfig config = KylinConfig.getInstanceFromEnv();
+        config.setProperty("kylin.query.cache-enabled", "true");
+        config.setProperty("kylin.query.lazy-query-enabled", "true");
+
+        String badSql = "select with syntax error";
+
+        SQLRequest request = new SQLRequest();
+        request.setProject("default");
+        request.setSql(badSql);
+
+        try (SetAndUnsetThreadLocalConfig autoUnset = KylinConfig.setAndUnsetThreadLocalConfig(config)) {
+            queryService.doQueryWithCache(request, false);
+        } catch (Exception e) {
+            // expected error
+            Cache.ValueWrapper wrapper = cacheManager.getCache(QueryService.QUERY_CACHE).get(request.getCacheKey());
+            Assert.assertTrue(wrapper == null || wrapper.get() == null);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes
This PR fix the bug described in [KYLIN-4432](https://issues.apache.org/jira/browse/KYLIN-4432) that duplicated queries with sytax error take unexpect long time when lazy query enabled. 

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If this change need a document change, I will prepare another pr against the `document` branch
- [x] Any dependent changes have been merged

## Further comments
N/A
