### PR TITLE
KYLIN-4433 use cube config when uhc step enabled

### DIFF
--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/steps/CreateDictionaryJob.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/steps/CreateDictionaryJob.java
@@ -82,9 +82,9 @@ public class CreateDictionaryJob extends AbstractHadoopJob {
                 CubeManager cubeManager = CubeManager.getInstance(config);
                 CubeInstance cube = cubeManager.getCube(cubeName);
                 List<TblColRef> uhcColumns = cube.getDescriptor().getAllUHCColumns();
-
+                KylinConfig cubeConfig = cube.getConfig();
                 Path colDir;
-                if (config.isBuildUHCDictWithMREnabled() && uhcColumns.contains(col)) {
+                if (cubeConfig.isBuildUHCDictWithMREnabled() && uhcColumns.contains(col)) {
                     colDir = new Path(dictPath, col.getIdentity());
                 } else {
                     colDir = new Path(factColumnsInputPath, col.getIdentity());


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KYLIN-4433
    If the system level configuration is used, it will cause the dictionary to be built repeatedly, so I think the configuration of the cube should be used here.
    Thanks!