### PR TITLE
KYLIN-4437 repalce deprecated mapred.job.name & set cube in hive mr …

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/HiveCmdBuilder.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/HiveCmdBuilder.java
@@ -52,7 +52,7 @@ public class HiveCmdBuilder {
         hiveConfProps = SourceConfigurationUtil.loadHiveConfiguration();
         hiveConfProps.putAll(kylinConfig.getHiveConfigOverride());
         if (StringUtils.isNotEmpty(jobName)) {
-            addStatement("set mapred.job.name='" + jobName + "';");
+            addStatement("set mapreduce.job.name=" + jobName + ";");
         }
     }
 

--- a/core-common/src/test/java/org/apache/kylin/common/util/HiveCmdBuilderTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/util/HiveCmdBuilderTest.java
@@ -66,7 +66,7 @@ public class HiveCmdBuilderTest {
         hiveCmdBuilder.setHiveConfProps(hiveProps);
         hiveCmdBuilder.overwriteHiveProps(hivePropsOverwrite);
         assertEquals(
-                "hive -e \"set mapred.job.name='test HiveCLI';\nUSE default;\nDROP TABLE \\`test\\`;\nSHOW\n TABLES;\n\" --hiveconf hive.execution.engine=tez",
+                "hive -e \"set mapreduce.job.name=test HiveCLI;\nUSE default;\nDROP TABLE \\`test\\`;\nSHOW\n TABLES;\n\" --hiveconf hive.execution.engine=tez",
                 hiveCmdBuilder.build());
     }
 

--- a/source-hive/src/main/java/org/apache/kylin/source/hive/CreateFlatHiveTableStep.java
+++ b/source-hive/src/main/java/org/apache/kylin/source/hive/CreateFlatHiveTableStep.java
@@ -47,7 +47,7 @@ public class CreateFlatHiveTableStep extends AbstractExecutable {
     private static final Pattern HDFS_LOCATION = Pattern.compile("LOCATION \'(.*)\';");
 
     protected void createFlatHiveTable(KylinConfig config) throws IOException {
-        final HiveCmdBuilder hiveCmdBuilder = new HiveCmdBuilder(getName());
+        final HiveCmdBuilder hiveCmdBuilder = new HiveCmdBuilder(getName() + " " + getCubeName() + " " + getId());
         hiveCmdBuilder.overwriteHiveProps(config.getHiveConfigOverride());
         hiveCmdBuilder.addStatement(getInitStatement());
         hiveCmdBuilder.addStatement(getCreateTableStatement());

--- a/source-hive/src/main/java/org/apache/kylin/source/hive/RedistributeFlatHiveTableStep.java
+++ b/source-hive/src/main/java/org/apache/kylin/source/hive/RedistributeFlatHiveTableStep.java
@@ -45,7 +45,7 @@ public class RedistributeFlatHiveTableStep extends AbstractExecutable {
     }
 
     private void redistributeTable(KylinConfig config, int numReducers) throws IOException {
-        final HiveCmdBuilder hiveCmdBuilder = new HiveCmdBuilder(getName());
+        final HiveCmdBuilder hiveCmdBuilder = new HiveCmdBuilder(getName() + " " + getCubeName() + " " + getId());
         hiveCmdBuilder.overwriteHiveProps(config.getHiveConfigOverride());
         hiveCmdBuilder.addStatement(getInitStatement());
         hiveCmdBuilder.addStatement("set mapreduce.job.reduces=" + numReducers + ";\n");


### PR DESCRIPTION
…name

## Proposed changes

see: https://issues.apache.org/jira/browse/KYLIN-4437
mapred.job.name is deprecated. Change to mapreduce.job.name is better. 

add cube name and job id in MR job name, could help admins to find the job in yarn cluster.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments
