### PR TITLE
KYLIN-4478 Resolve Issue: Use secure AES/CFB/PKCS5Padding instead of insecure AES/ECB/PKCS5Padding

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/EncryptUtil.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/EncryptUtil.java
@@ -52,7 +52,7 @@ public class EncryptUtil {
             return null;
         }
         try {
-            Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING");
+            Cipher cipher = Cipher.getInstance("AES/CFB/PKCS5Padding");
             final SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
             cipher.init(Cipher.DECRYPT_MODE, secretKey);
             final String decryptedString = new String(cipher.doFinal(Base64.decodeBase64(strToDecrypt)), StandardCharsets.UTF_8);

--- a/core-common/src/main/java/org/apache/kylin/common/util/EncryptUtil.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/EncryptUtil.java
@@ -36,7 +36,7 @@ public class EncryptUtil {
             return null;
         }
         try {
-            Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+            Cipher cipher = Cipher.getInstance("AES/CFB/PKCS5Padding");
             final SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
             cipher.init(Cipher.ENCRYPT_MODE, secretKey);
             final String encryptedString = Base64.encodeBase64String(cipher.doFinal(strToEncrypt.getBytes(

--- a/engine-mr/src/main/java/org/apache/kylin/engine/mr/common/DefaultSslProtocolSocketFactory.java
+++ b/engine-mr/src/main/java/org/apache/kylin/engine/mr/common/DefaultSslProtocolSocketFactory.java
@@ -130,7 +130,7 @@ public class DefaultSslProtocolSocketFactory implements SecureProtocolSocketFact
 
     private static SSLContext createEasySSLContext() {
         try {
-            SSLContext context = SSLContext.getInstance("TLS");
+            SSLContext context = SSLContext.getInstance("TLSv1.3");
             context.init(null, new TrustManager[] { new DefaultX509TrustManager(null) }, null);
 
             return context;


### PR DESCRIPTION
Used secure AES/CFB/PKCS5Padding as `Cipher.getInstance`'s argument, instead of insecure AES/ECB/PKCS5Padding, to resolve [KYLIN-4478](https://issues.apache.org/jira/browse/KYLIN-4478)

Please ignore the changes for KYLIN-4477 for this pull request. It has been added here by mistake. A separate Pull request has been created for that.