### PR TITLE
[Bugfix] fix error with sending mail on ssl

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/MailService.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/MailService.java
@@ -89,6 +89,7 @@ public class MailService {
         Email email = new HtmlEmail();
         email.setHostName(host);
         email.setStartTLSEnabled(starttlsEnabled);
+        email.setSSLOnConnect(starttlsEnabled);
         if (starttlsEnabled) {
             email.setSslSmtpPort(port);
         } else {


### PR DESCRIPTION
## Proposed changes

Here is context of this problem：https://www.mail-archive.com/user@kylin.apache.org/msg04009.html

When I set `starttlsEnabled` to true, and specify a ssl port as 465,  the email could not be sent by this ssl port. It still use 25 default port. 

The root cause is, with such config above, HTMLEmail client doesn't enable ssl connection, so we need to enable ssl connection by `setSSLOnConnect` as well when using ssl port.

## Types of changes
[Bugfix] fix error with sending mail on ssl