### PR TITLE
KYLIN-2971 Fix the wrong "Realization Names" and missing "Cuboid Ids" in logQuery when hit cache

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/service/QueryService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/QueryService.java
@@ -55,6 +55,8 @@ import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.prepare.OnlyPrepareEarlyAbortException;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
@@ -325,9 +327,27 @@ public class QueryService extends BasicService {
             }
         }
 
+        // if Realization Names is empty, get value from SQLResponse.
         if (realizationNames.isEmpty()) {
             if (!Strings.isNullOrEmpty(response.getCube())) {
                 realizationNames.addAll(Lists.newArrayList(StringUtil.splitByComma(response.getCube())));
+            }
+        }
+
+        // if Cuboid Ids is empty, get value from SQLResponse.
+        if (cuboidIds.isEmpty()) {
+            List<QueryContext.CubeSegmentStatisticsResult> cubeSegmentStatisticsList =
+                    response.getCubeSegmentStatisticsList();
+            if (CollectionUtils.isNotEmpty(cubeSegmentStatisticsList)) {
+                cubeSegmentStatisticsList.forEach(cubeSegmentStatResult -> {
+                    if (MapUtils.isNotEmpty(cubeSegmentStatResult.getCubeSegmentStatisticsMap())) {
+                        cubeSegmentStatResult.getCubeSegmentStatisticsMap().values().forEach(cubeSegmentStatMap -> {
+                            cubeSegmentStatMap.values().forEach(cubeSegmentStat -> {
+                                cuboidIds.add(cubeSegmentStat.getTargetCuboidId());
+                            });
+                        });
+                    }
+                });
             }
         }
 
@@ -411,6 +431,9 @@ public class QueryService extends BasicService {
         queryContext.setProject(sqlRequest.getProject());
 
         try (SetThreadName ignored = new SetThreadName("Query %s", queryContext.getQueryId())) {
+            // force clear the query context before a new query
+            OLAPContext.clearThreadLocalContexts();
+
             SQLResponse sqlResponse = null;
             String sql = sqlRequest.getSql();
             String project = sqlRequest.getProject();
@@ -660,8 +683,6 @@ public class QueryService extends BasicService {
             parameters.put(OLAPContext.PRM_USER_AUTHEN_INFO, userInfo);
             parameters.put(OLAPContext.PRM_ACCEPT_PARTIAL_RESULT, String.valueOf(sqlRequest.isAcceptPartial()));
             OLAPContext.setParameters(parameters);
-            // force clear the query context before a new query
-            OLAPContext.clearThreadLocalContexts();
 
             // special case for prepare query.
             List<List<String>> results = Lists.newArrayList();


### PR DESCRIPTION
**Problems:**
1. The value of "Realization Names" in logQuery is wrong when query two different sqls within the same thread and second sql hits cache:
Example:
 1). query Q1 hit project P1 and cube C1;
 2). query Q2 hit project P2 and cube C2 in the same thread with Q1;
 3). Q1 comes again and hits cache, it will show project P1 and cube C2. However, it should be cube C1.

2. Missing "Cuboid Ids" in logQuery when hit cache in a new thread which does not have OLAPContext;

**Solutions:**
1. Call 'OLAPContext.clearThreadLocalContexts()' before a query starts;
2. Get "Cuboid Ids" from SQLResponse when "OLAPContext.getThreadLocalContexts()" is null;

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
