### PR TITLE
Add considerations for hbase-shad-client -*.jar

### DIFF
--- a/build/bin/find-hbase-dependency.sh
+++ b/build/bin/find-hbase-dependency.sh
@@ -36,7 +36,7 @@ arr=(`echo $hbase_classpath | cut -d ":" -f 1- | sed 's/:/ /g'`)
 hbase_common_path=
 for data in ${arr[@]}
 do
-    result=`echo $data | grep -e 'hbase-common[a-z0-9A-Z\.-]*jar' | grep -v tests`
+    result=`echo $data | grep -e 'hbase-[common,shaded\-client][a-z0-9A-Z\.-]*jar' | grep -v tests`
     if [ $result ]
     then
         hbase_common_path=$data


### PR DESCRIPTION
When work with HBase 2.1, the script `find-hbase-dependency.sh`  returns `hbase-common lib not found`,
because the output of this command `hbase classpath` does not contain `hbase-common-*.jar` but `hbase-shaded-client-*.jar`

## Proposed changes

When looking for hbase dependencies, add considerations for `hbase-shaded-client -*.jar`.


## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
