### PR TITLE
KYLIN-4548 fix garbled characters in sql when exporting query result

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -134,6 +134,7 @@ public class QueryController extends BasicController {
     @RequestMapping(value = "/query/format/{format}", method = RequestMethod.GET, produces = { "application/json" })
     @ResponseBody
     public void downloadQueryResult(@PathVariable String format, SQLRequest sqlRequest, HttpServletResponse response) {
+        sqlRequest.setSql(new String(sqlRequest.getSql().getBytes("iso8859-1"),"UTF-8"));
         KylinConfig config = queryService.getConfig();
         Message msg = MsgPicker.getMsg();
 


### PR DESCRIPTION
when the SQL that needs to export the query results has Chinese, garbled characters will be generated.
jira: https://issues.apache.org/jira/browse/KYLIN-4548
