### PR TITLE
KYLIN-4548 fix garbled characters in sql when exporting query result

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/QueryController.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.rest.controller;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
@@ -133,7 +134,8 @@ public class QueryController extends BasicController {
 
     @RequestMapping(value = "/query/format/{format}", method = RequestMethod.GET, produces = { "application/json" })
     @ResponseBody
-    public void downloadQueryResult(@PathVariable String format, SQLRequest sqlRequest, HttpServletResponse response) {
+    public void downloadQueryResult(@PathVariable String format, SQLRequest sqlRequest, HttpServletResponse response) throws UnsupportedEncodingException {
+        sqlRequest.setSql(new String(sqlRequest.getSql().getBytes("iso8859-1"),"UTF-8"));
         KylinConfig config = queryService.getConfig();
         Message msg = MsgPicker.getMsg();
 


### PR DESCRIPTION
when the SQL that needs to export the query results has Chinese, garbled characters will be generated.
jira: https://issues.apache.org/jira/browse/KYLIN-4548