### PR TITLE
KYLIN-4576 add some hint of password length

### DIFF
--- a/webapp/app/partials/admin/change_pwd.html
+++ b/webapp/app/partials/admin/change_pwd.html
@@ -51,8 +51,8 @@
       <div class="form-group">
         <label><b>User New Password</b></label>
         <div class="clearfix">
-          <input required ng-pattern="pwdPattern" name="pwd_input" type="password" class="form-control" 
-                 placeholder="The password should contain at least one number, letter and special character（~!@#$%^&*(){}|:&quot;\<\>?[];\',./`)."
+          <input required ng-pattern="pwdPattern" name="pwd_input" type="password" class="form-control"
+                 placeholder="The password should have at least 8 characters, and contain at least one number, letter and special character（~!@#$%^&*(){}|:&quot;\<\>?[];\',./`)."
                  ng-model="changePwdUser.newPassword"/>
           <span class="text-warning"
                           ng-if="change_pwd_form.pwd_input.$error.required  && change_pwd_form.pwd_input.$dirty"
@@ -65,8 +65,8 @@
       <div class="form-group">
         <label><b>Confirm New Password</b></label>
         <div class="clearfix">
-          <input required name="pwd_new_input" type="password" class="form-control" 
-                 placeholder="The password should contain at least one number, letter and special character（~!@#$%^&*(){}|:&quot;\<\>?[];\',./`)." 
+          <input required name="pwd_new_input" type="password" class="form-control"
+                 placeholder="The password should have at least 8 characters, and contain at least one number, letter and special character（~!@#$%^&*(){}|:&quot;\<\>?[];\',./`)."
                  ng-model="changePwdUser.repeatPassword"/>
             <span class="text-warning"
                  ng-if="user_create_form.pwd_new_input.$error.required  && user_create_form.pwd_new_input.$dirty"

--- a/webapp/app/partials/admin/user_create.html
+++ b/webapp/app/partials/admin/user_create.html
@@ -41,7 +41,7 @@
       <div class="form-group">
         <label><b>User Password</b></label>
         <div class="clearfix">
-          <input ng-pattern="pwdPattern" required name="pwd_input" type="password" class="form-control" placeholder="The password should contain at least one number, letter and special character（~!@#$%^&*(){}|:&quot;\<\>?[];\',./`)." ng-model="user.password"/>
+          <input ng-pattern="pwdPattern" required name="pwd_input" type="password" class="form-control" placeholder="The password should have at least 8 characters, and contain at least one number, letter and special character（~!@#$%^&*(){}|:&quot;\<\>?[];\',./`)." ng-model="user.password"/>
           <span class="text-warning"
                           ng-if="user_create_form.pwd_input.$error.required  && user_create_form.pwd_input.$dirty"
                     >&nbsp;The password is required</span>


### PR DESCRIPTION
## Proposed changes

add some hint of password length in frontend password placeholder

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

