### PR TITLE
KYLIN-4577 Throws UnrecognizedPropertyException when server self discovery enables

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/zookeeper/KylinServerDiscovery.java
+++ b/core-common/src/main/java/org/apache/kylin/common/zookeeper/KylinServerDiscovery.java
@@ -120,9 +120,17 @@ public class KylinServerDiscovery implements Closeable {
             serviceCache.start();
 
             registerSelf();
+            int i = 1;
+            long maxWaitingTime = 60 * 1000L; // 1 min
             while (!isFinishInit.get()) {
                 logger.info("Haven't registered, waiting ...");
-                Thread.sleep(100L);
+                long waitingTime = 100L * i * i;
+                if (waitingTime > maxWaitingTime) {
+                    waitingTime = maxWaitingTime;
+                } else {
+                    i++;
+                }
+                Thread.sleep(waitingTime);
             }
         } catch (Exception e) {
             throw new RuntimeException("Fail to initialize due to ", e);

--- a/core-common/src/test/java/org/apache/kylin/common/zookeeper/KylinServerDiscoveryTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/zookeeper/KylinServerDiscoveryTest.java
@@ -29,7 +29,6 @@ import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
 import org.apache.kylin.common.util.LocalFileMetadataTestCase;
 import org.apache.kylin.common.util.ZKUtil;
 import org.junit.After;
@@ -77,7 +76,8 @@ public class KylinServerDiscoveryTest extends LocalFileMetadataTestCase {
         CuratorFramework curatorClient = null;
         try {
             String servicePath = KylinServerDiscovery.SERVICE_PATH;
-            final JsonInstanceSerializer<LinkedHashMap> serializer = new JsonInstanceSerializer<>(LinkedHashMap.class);
+            final KylinServerDiscovery.JsonInstanceSerializer<LinkedHashMap> serializer =
+                    new KylinServerDiscovery.JsonInstanceSerializer<>(LinkedHashMap.class);
             curatorClient = ZKUtil.newZookeeperClient(zkString, new ExponentialBackoffRetry(3000, 3));
             serviceDiscovery = ServiceDiscoveryBuilder.builder(LinkedHashMap.class).client(curatorClient)
                     .basePath(servicePath).serializer(serializer).build();


### PR DESCRIPTION
Problem:
When server self discovery enables, it throws UnrecognizedPropertyException on some env, for example: cdh 5.7.

Root cause:
The json of ServiceInstance is incompatible, related to the issue of curator:  https://issues.apache.org/jira/browse/CURATOR-394

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
