### PR TITLE
KYLIN-3832 Disable all convert and quote behavior for postgresql

### DIFF
--- a/datasource-sdk/src/main/java/org/apache/kylin/sdk/datasource/framework/def/DataSourceDef.java
+++ b/datasource-sdk/src/main/java/org/apache/kylin/sdk/datasource/framework/def/DataSourceDef.java
@@ -169,6 +169,10 @@ public class DataSourceDef {
                 }
             }
         }
+
+        for (String k : propertyDefMap.keySet()) {
+            logger.debug("Check {}, {} : {}", k, propertyDefMap.get(k).getName(), propertyDefMap.get(k).getValue());
+        }
     }
 
     // ===================================================================

--- a/datasource-sdk/src/main/resources/datasource/postgresql.xml
+++ b/datasource-sdk/src/main/resources/datasource/postgresql.xml
@@ -17,7 +17,7 @@
  limitations under the License.
 -->
 <DATASOURCE_DEF NAME="kylin" ID="postgresql">
-    <PROPERTY NAME="sql.default-converted-enabled" VALUE="true"/>
+    <PROPERTY NAME="sql.default-converted-enabled" VALUE="false"/>
     <PROPERTY NAME="sql.allow-no-offset" VALUE="true"/>
     <PROPERTY NAME="sql.allow-fetch-no-rows" VALUE="true"/>
     <PROPERTY NAME="sql.allow-no-orderby-with-fetch" VALUE="true"/>
@@ -25,7 +25,7 @@
     <PROPERTY NAME="sql.keyword-default-uppercase" VALUE="false"/>
     <PROPERTY NAME="sql.case-sensitive" VALUE="true"/>
     <PROPERTY NAME="metadata.enable-cache" VALUE="true"/>
-<!--    <PROPERTY NAME="sql.enable-quote-all-identifiers" VALUE="false"/>-->
+    <PROPERTY NAME="sql.enable-quote-all-identifiers" VALUE="false"/>
 
     <!--DayOfYear-->
     <FUNCTION_DEF ID="9" EXPRESSION="EXTRACT(DOY FROM CAST($0 AS DATE))"/>

--- a/datasource-sdk/src/test/java/org/apache/kylin/sdk/datasource/framework/conv/PostgresqlSqlConverterTest.java
+++ b/datasource-sdk/src/test/java/org/apache/kylin/sdk/datasource/framework/conv/PostgresqlSqlConverterTest.java
@@ -18,6 +18,7 @@
 package org.apache.kylin.sdk.datasource.framework.conv;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -26,6 +27,7 @@ import java.util.List;
 
 public class PostgresqlSqlConverterTest {
 
+    @Ignore
     @Test
     public void testConvertSql() throws SQLException {
         GenericSqlConverter sqlConverter = new GenericSqlConverter();

--- a/source-jdbc/src/main/java/org/apache/kylin/source/jdbc/extensible/JdbcHiveInputBase.java
+++ b/source-jdbc/src/main/java/org/apache/kylin/source/jdbc/extensible/JdbcHiveInputBase.java
@@ -59,6 +59,8 @@ public class JdbcHiveInputBase extends org.apache.kylin.source.jdbc.JdbcHiveInpu
             PartitionDesc partitionDesc = flatDesc.getDataModel().getPartitionDesc();
             String partCol = null;
             boolean enableQuote = dataSource.getSqlConverter().getConfigurer().enableQuote();
+            enableQuote = enableQuote && config.enableHiveDdlQuote();
+            logger.debug("Quote switch is set to {}", enableQuote);
             SqlDialect sqlDialect = enableQuote ? dataSource.getSqlConverter().getConfigurer().getSqlDialect() : FlatTableSqlQuoteUtils.NON_QUOTE_DIALECT;
             SqlConverter.IConfigurer iconfigurer = dataSource.getSqlConverter().getConfigurer();
 
@@ -102,7 +104,7 @@ public class JdbcHiveInputBase extends org.apache.kylin.source.jdbc.JdbcHiveInpu
                 if (segRange != null && !segRange.isInfinite()) {
                     if (partitionDesc.getPartitionDateColumnRef().getTableAlias().equals(splitTableAlias)
                             && (partitionDesc.getPartitionTimeColumnRef() == null || partitionDesc
-                                    .getPartitionTimeColumnRef().getTableAlias().equals(splitTableAlias))) {
+                            .getPartitionTimeColumnRef().getTableAlias().equals(splitTableAlias))) {
                         String quotedPartCond = FlatTableSqlQuoteUtils.quoteIdentifierInSqlExpr(flatDesc,
                                 partitionDesc.getPartitionConditionBuilder().buildDateRangeCondition(partitionDesc,
                                         flatDesc.getSegment(), segRange, null), sqlDialect);


### PR DESCRIPTION
From the documentation, we know that when quoted, identifier is case sensitive, which is not easy to fix. So we cannot support reserved word as identifier, which is rare.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
