### PR TITLE
KYLIN-4598 Missing dependency when run kylin.sh org.apache.kylin.*

### DIFF
--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -40,10 +40,16 @@ function retrieveDependency() {
         source ${dir}/cached-hive-dependency.sh
         source ${dir}/cached-hbase-dependency.sh
         source ${dir}/cached-hadoop-conf-dir.sh
+        source ${dir}/cached-kafka-dependency.sh
+        source ${dir}/cached-spark-dependency.sh
+        source ${dir}/cached-flink-dependency.sh
     else
         source ${dir}/find-hive-dependency.sh
         source ${dir}/find-hbase-dependency.sh
         source ${dir}/find-hadoop-conf-dir.sh
+        source ${dir}/find-kafka-dependency.sh
+        source ${dir}/find-spark-dependency.sh
+        source ${dir}/find-flink-dependency.sh
     fi
 
     #retrive $KYLIN_EXTRA_START_OPTS


### PR DESCRIPTION
Problems:
It throws 'NoClassDefFoundError: org/apache/kafka/clients/producer/Producer' when run kylin.sh org.apache.kylin.source.kafka.util.KafkaSampleProducer.

Solutions:
Add 'export kafka_dependency' before export HBASE_CLASSPATH in kylin.sh

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
