### PR TITLE
KYLIN-4597 Fix NPE when download diagnosis info for a job

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/CliCommandExecutor.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/CliCommandExecutor.java
@@ -163,7 +163,7 @@ public class CliCommandExecutor {
         }
     }
 
-    public static final String COMMAND_BLOCK_LIST = "[ &`>|{}()$;\\#~!+*\\\\]+";
+    public static final String COMMAND_BLOCK_LIST = "[ &`>|{}()$;\\-#~!+*\\\\]+";
     public static final String COMMAND_WHITE_LIST = "[^\\w%,@/:=?.\"\\[\\]]";
     public static final String HIVE_BLOCK_LIST = "[ <>()$;\\-#!+*\"'/=%@]+";
 

--- a/server-base/src/main/java/org/apache/kylin/rest/controller/DiagnosisController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/DiagnosisController.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.kylin.common.persistence.AutoDeleteDirectory;
-import org.apache.kylin.common.util.CliCommandExecutor;
 import org.apache.kylin.metadata.badquery.BadQueryEntry;
 import org.apache.kylin.metadata.badquery.BadQueryHistory;
 import org.apache.kylin.rest.exception.InternalErrorException;
@@ -80,7 +79,7 @@ public class DiagnosisController extends BasicController {
     public void dumpProjectDiagnosisInfo(@PathVariable String project, final HttpServletRequest request,
             final HttpServletResponse response) {
         try (AutoDeleteDirectory diagDir = new AutoDeleteDirectory("diag_project", "")) {
-            String filePath = dgService.dumpProjectDiagnosisInfo(CliCommandExecutor.checkParameter(project), diagDir.getFile());
+            String filePath = dgService.dumpProjectDiagnosisInfo(project, diagDir.getFile());
             setDownloadResponse(filePath, response);
         } catch (IOException e) {
             throw new InternalErrorException("Failed to dump project diagnosis info. " + e.getMessage(), e);
@@ -96,7 +95,7 @@ public class DiagnosisController extends BasicController {
     public void dumpJobDiagnosisInfo(@PathVariable String jobId, final HttpServletRequest request,
             final HttpServletResponse response) {
         try (AutoDeleteDirectory diagDir = new AutoDeleteDirectory("diag_job", "")) {
-            String filePath = dgService.dumpJobDiagnosisInfo(CliCommandExecutor.checkParameter(jobId), diagDir.getFile());
+            String filePath = dgService.dumpJobDiagnosisInfo(jobId, diagDir.getFile());
             setDownloadResponse(filePath, response);
         } catch (IOException e) {
             throw new InternalErrorException("Failed to dump job diagnosis info. " + e.getMessage(), e);

--- a/server-base/src/main/java/org/apache/kylin/rest/msg/CnMessage.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/msg/CnMessage.java
@@ -404,6 +404,14 @@ public class CnMessage extends Message {
         return "找不到诊断包, 路径: %s";
     }
 
+    public String getDIAG_PROJECT_NOT_FOUND() {
+        return "找不到项目: %s.";
+    }
+
+    public String getDIAG_JOBID_NOT_FOUND() {
+        return "找不到任务ID: %s.";
+    }
+
     // Encoding
     public String getVALID_ENCODING_NOT_AVAILABLE() {
         return "无法为数据类型: %s 提供合法的编码";

--- a/server-base/src/main/java/org/apache/kylin/rest/msg/Message.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/msg/Message.java
@@ -417,6 +417,14 @@ public class Message {
         return "Diagnosis package not found in directory: %s.";
     }
 
+    public String getDIAG_PROJECT_NOT_FOUND() {
+        return "Can not find project: %s.";
+    }
+
+    public String getDIAG_JOBID_NOT_FOUND() {
+        return "Can not find job id: %s.";
+    }
+
     // Encoding
     public String getVALID_ENCODING_NOT_AVAILABLE() {
         return "Can not provide valid encodings for datatype: %s.";

--- a/server-base/src/main/java/org/apache/kylin/rest/util/AclEvaluate.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/util/AclEvaluate.java
@@ -60,25 +60,42 @@ public class AclEvaluate {
         return getProjectInstance(projectName);
     }
 
+    public void checkProjectAdminPermission(ProjectInstance projectInstance) {
+        aclUtil.hasProjectAdminPermission(projectInstance);
+    }
+
+    //for raw project
+    public void checkProjectReadPermission(ProjectInstance projectInstance) {
+        aclUtil.hasProjectReadPermission(projectInstance);
+    }
+
+    public void checkProjectWritePermission(ProjectInstance projectInstance) {
+        aclUtil.hasProjectWritePermission(projectInstance);
+    }
+
+    public void checkProjectOperationPermission(ProjectInstance projectInstance) {
+        aclUtil.hasProjectOperationPermission(projectInstance);
+    }
+
     public void checkProjectAdminPermission(String projectName) {
         ProjectInstance projectInstance = getProjectInstance(projectName);
-        aclUtil.hasProjectAdminPermission(projectInstance);
+        checkProjectAdminPermission(projectInstance);
     }
 
     //for raw project
     public void checkProjectReadPermission(String projectName) {
         ProjectInstance projectInstance = getProjectInstance(projectName);
-        aclUtil.hasProjectReadPermission(projectInstance);
+        checkProjectReadPermission(projectInstance);
     }
 
     public void checkProjectWritePermission(String projectName) {
         ProjectInstance projectInstance = getProjectInstance(projectName);
-        aclUtil.hasProjectWritePermission(projectInstance);
+        checkProjectWritePermission(projectInstance);
     }
 
     public void checkProjectOperationPermission(String projectName) {
         ProjectInstance projectInstance = getProjectInstance(projectName);
-        aclUtil.hasProjectOperationPermission(projectInstance);
+        checkProjectOperationPermission(projectInstance);
     }
 
     //for cube acl entity


### PR DESCRIPTION
Problems:
When download diagnosis info for a job, it throws NPE.

Solutions:
Don't replace '-' to '' for job id, which will change the value of job id and can't find the job.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
