### PR TITLE
KYLIN-4771 Clear the recordCachePool when the deadline has reached

### DIFF
--- a/stream-core/src/main/java/org/apache/kylin/stream/core/query/MultiThreadsResultCollector.java
+++ b/stream-core/src/main/java/org/apache/kylin/stream/core/query/MultiThreadsResultCollector.java
@@ -148,7 +148,7 @@ public class MultiThreadsResultCollector extends ResultCollector {
                 result.startRead();
                 for (Record record : result) {
                     offserTimeout = deadline - System.currentTimeMillis();
-                    if (!recordCachePool.offer(record, offserTimeout, TimeUnit.MILLISECONDS)) {
+                    if (!recordCachePool.offer(record.copy(), offserTimeout, TimeUnit.MILLISECONDS)) {
                         logger.warn("Timeout when offer to recordCachePool, deadline: {}, offser Timeout: {}", deadline, offserTimeout);
                         break;
                     }


### PR DESCRIPTION
## Proposed changes

1、Clear the recordCachePool when the deadline has reached.
2、Add timeout for the recordCachePool offer.
https://issues.apache.org/jira/projects/KYLIN/issues/KYLIN-4771?filter=reportedbyme


## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
