### PR TITLE
KYLIN-4791 Fix exception 'UnsupportedOperationException: empty.reduceLeft' when there are cast expressions in the filters of FilePruner

### DIFF
--- a/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
+++ b/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
@@ -260,13 +260,19 @@ class FilePruner(
     val filteredStatuses = if (filters.isEmpty) {
       segDirs
     } else {
-      val reducedFilter = filters.flatMap(DataSourceStrategy.translateFilter).reduceLeft(And)
-      segDirs.filter {
-        e => {
-          val tsRange = cubeInstance.getSegment(e.segmentName, SegmentStatusEnum.READY).getTSRange
-          SegFilters(tsRange.startValue, tsRange.endValue, pattern).foldFilter(reducedFilter) match {
-            case Trivial(true) => true
-            case Trivial(false) => false
+      val translatedFilter = filters.map(filter => convertCastFilter(filter))
+        .flatMap(DataSourceStrategy.translateFilter)
+      if (translatedFilter.isEmpty) {
+        segDirs
+      } else {
+        val reducedFilter = translatedFilter.reduceLeft(And)
+        segDirs.filter {
+          e => {
+            val tsRange = cubeInstance.getSegment(e.segmentName, SegmentStatusEnum.READY).getTSRange
+            SegFilters(tsRange.startValue, tsRange.endValue, pattern).foldFilter(reducedFilter) match {
+              case Trivial(true) => true
+              case Trivial(false) => false
+            }
           }
         }
       }
@@ -275,32 +281,31 @@ class FilePruner(
     filteredStatuses
   }
 
-    private def pruneShards(
-      filters: Seq[Expression],
-      segDirs: Seq[SegmentDirectory]): Seq[SegmentDirectory] = {
-      val filteredStatuses = if (layoutEntity.getShardByColumns.size() != 1) {
-        segDirs
-      } else {
-        val normalizedFiltersAndExpr = filters.reduce(expressions.And)
+  private def pruneShards(filters: Seq[Expression],
+                           segDirs: Seq[SegmentDirectory]): Seq[SegmentDirectory] = {
+    val filteredStatuses = if (layoutEntity.getShardByColumns.size() != 1) {
+      segDirs
+    } else {
+      val normalizedFiltersAndExpr = filters.reduce(expressions.And)
 
-        val pruned = segDirs.map { case SegmentDirectory(segName, segIdentifier, files) =>
-          val segment = cubeInstance.getSegment(segName, SegmentStatusEnum.READY);
-          val partitionNumber = segment.getCuboidShardNum(layoutEntity.getId).toInt
-          require(partitionNumber > 0, "Shards num with shard by col should greater than 0.")
+      val pruned = segDirs.map { case SegmentDirectory(segName, segIdentifier, files) =>
+        val segment = cubeInstance.getSegment(segName, SegmentStatusEnum.READY);
+        val partitionNumber = segment.getCuboidShardNum(layoutEntity.getId).toInt
+        require(partitionNumber > 0, "Shards num with shard by col should greater than 0.")
 
-          val bitSet = getExpressionShards(normalizedFiltersAndExpr, shardByColumn.name, partitionNumber)
+        val bitSet = getExpressionShards(normalizedFiltersAndExpr, shardByColumn.name, partitionNumber)
 
-          val selected = files.filter(f => {
-            val partitionId = FilePruner.getPartitionId(f.getPath)
-            bitSet.get(partitionId)
-          })
-          SegmentDirectory(segName, segIdentifier, selected)
-        }
-        logInfo(s"Selected files after shards pruning:" + pruned.flatMap(_.files).map(_.getPath.toString).mkString(";"))
-        pruned
+        val selected = files.filter(f => {
+          val partitionId = FilePruner.getPartitionId(f.getPath)
+          bitSet.get(partitionId)
+        })
+        SegmentDirectory(segName, segIdentifier, selected)
       }
-      filteredStatuses
+      logInfo(s"Selected files after shards pruning:" + pruned.flatMap(_.files).map(_.getPath.toString).mkString(";"))
+      pruned
     }
+    filteredStatuses
+  }
 
   override lazy val inputFiles: Array[String] = Array.empty[String]
 
@@ -356,6 +361,39 @@ class FilePruner(
         val matchedShards = new BitSet(numShards)
         matchedShards.setUntil(numShards)
         matchedShards
+    }
+  }
+
+  //  translate for filter type match
+  private def convertCastFilter(filter: Expression): Expression = {
+    filter match {
+      case expressions.EqualTo(expressions.Cast(a: Attribute, _, _), Literal(v, t)) =>
+        expressions.EqualTo(a, Literal(v, t))
+      case expressions.EqualTo(Literal(v, t), expressions.Cast(a: Attribute, _, _)) =>
+        expressions.EqualTo(Literal(v, t), a)
+      case expressions.GreaterThan(expressions.Cast(a: Attribute, _, _), Literal(v, t)) =>
+        expressions.GreaterThan(a, Literal(v, t))
+      case expressions.GreaterThan(Literal(v, t), expressions.Cast(a: Attribute, _, _)) =>
+        expressions.GreaterThan(Literal(v, t), a)
+      case expressions.LessThan(expressions.Cast(a: Attribute, _, _), Literal(v, t)) =>
+        expressions.LessThan(a, Literal(v, t))
+      case expressions.LessThan(Literal(v, t), expressions.Cast(a: Attribute, _, _)) =>
+        expressions.LessThan(Literal(v, t), a)
+      case expressions.GreaterThanOrEqual(expressions.Cast(a: Attribute, _, _), Literal(v, t)) =>
+        expressions.GreaterThanOrEqual(a, Literal(v, t))
+      case expressions.GreaterThanOrEqual(Literal(v, t), expressions.Cast(a: Attribute, _, _)) =>
+        expressions.GreaterThanOrEqual(Literal(v, t), a)
+      case expressions.LessThanOrEqual(expressions.Cast(a: Attribute, _, _), Literal(v, t)) =>
+        expressions.LessThanOrEqual(a, Literal(v, t))
+      case expressions.LessThanOrEqual(Literal(v, t), expressions.Cast(a: Attribute, _, _)) =>
+        expressions.LessThanOrEqual(Literal(v, t), a)
+      case expressions.Or(left, right) =>
+        expressions.Or(convertCastFilter(left), convertCastFilter(right))
+      case expressions.And(left, right) =>
+        expressions.And(convertCastFilter(left), convertCastFilter(right))
+      case expressions.Not(child) =>
+        expressions.Not(convertCastFilter(child))
+      case _ => filter
     }
   }
 }


### PR DESCRIPTION
When execute function 'pruneSegments' of FilePruner, if there are some cast expressions in filter, it will throw exception 'UnsupportedOperationException: empty.reduceLeft'.

Solution:
Convert cast expressions in filter to attribute before translating filter.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
