### PR TITLE
KYLIN-4826 kylin.source.hive.warehouse-dir can't found bug fix

### DIFF
--- a/build/bin/find-hive-dependency.sh
+++ b/build/bin/find-hive-dependency.sh
@@ -207,7 +207,8 @@ hive_dependency=${hive_conf_path}:${hive_lib}:${hcatalog}
 verbose "hive dependency is $hive_dependency"
 export hive_dependency
 export hive_conf_path
-export hiveWarehouseDir=`hive -e 'set hive.metastore.warehouse.dir;' | awk '{split($0,a,"="); print a[2]}'`
-echo "export hiveWarehouseDir=$hiveWarehouseDir"
-echo "export hive_dependency=$hive_dependency
+export hive_warehouse_dir=`hive -e 'set hive.metastore.warehouse.dir;' | awk '{split($0,a,"="); print a[2]}'`
+echo "export hive_warehouse_dir=$hive_warehouse_dir"
+echo "export hive_warehouse_dir=$hive_warehouse_dir
+export hive_dependency=$hive_dependency
 export hive_conf_path=$hive_conf_path" > ${dir}/cached-hive-dependency.sh

--- a/build/bin/find-hive-dependency.sh
+++ b/build/bin/find-hive-dependency.sh
@@ -209,6 +209,7 @@ export hive_dependency
 export hive_conf_path
 export hive_warehouse_dir=`hive -e 'set hive.metastore.warehouse.dir;' | awk '{split($0,a,"="); print a[2]}'`
 echo "export hive_warehouse_dir=$hive_warehouse_dir"
+
 echo "export hive_warehouse_dir=$hive_warehouse_dir
 export hive_dependency=$hive_dependency
 export hive_conf_path=$hive_conf_path" > ${dir}/cached-hive-dependency.sh

--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -38,11 +38,40 @@ function retrieveDependency() {
     then
         echo "Using cached dependency..."
         source ${dir}/cached-hive-dependency.sh
+        if [ -z "${hive_warehouse_dir}" ] || [ -z "${hive_dependency}" ] || [ -z "${hive_conf_path}" ]; then
+          echo "WARNING: Using ${dir}/cached-hive-dependency.sh error,will be use ${dir}/find-hive-dependency.sh"
+          source ${dir}/find-hive-dependency.sh
+        fi
+
         source ${dir}/cached-hbase-dependency.sh
+        if [ -z "${hbase_dependency}" ]; then
+          echo "WARNING: Using ${dir}/cached-hbase-dependency.sh error,will be use ${dir}/find-hbase-dependency.sh"
+          source ${dir}/find-hbase-dependency.sh
+        fi
+
         source ${dir}/cached-hadoop-conf-dir.sh
+        if [ -z "${kylin_hadoop_conf_dir}" ]; then
+          echo "WARNING: Using ${dir}/cached-hadoop-conf-dir.sh error,will be use ${dir}/find-hadoop-conf-dir.sh"
+          source ${dir}/find-hadoop-conf-dir.sh
+        fi
+
         source ${dir}/cached-kafka-dependency.sh
+        if [ -z "${kafka_dependency}" ]; then
+          echo "WARNING: Using ${dir}/cached-kafka-dependency.sh error,will be use ${dir}/find-kafka-dependency.sh"
+          source ${dir}/find-kafka-dependency.sh
+        fi
+
         source ${dir}/cached-spark-dependency.sh
+        if [ -z "${spark_dependency}" ]; then
+          echo "WARNING: Using ${dir}/cached-spark-dependency.sh error,will be use ${dir}/find-spark-dependency.sh"
+          source ${dir}/find-spark-dependency.sh
+        fi
+
         source ${dir}/cached-flink-dependency.sh
+        if [ -z "${flink_dependency}" ]; then
+          echo "WARNING: Using ${dir}/cached-flink-dependency.sh error,will be use ${dir}/find-flink-dependency.sh"
+          source ${dir}/find-flink-dependency.sh
+        fi
     else
         source ${dir}/find-hive-dependency.sh
         source ${dir}/find-hbase-dependency.sh
@@ -57,7 +86,7 @@ function retrieveDependency() {
         echo "WARNING: ${dir}/setenv.sh is deprecated and ignored, please remove it and use ${KYLIN_HOME}/conf/setenv.sh instead"
         source ${dir}/setenv.sh
     fi
-    
+
     if [ -f "${KYLIN_HOME}/conf/setenv.sh" ]; then
         source ${KYLIN_HOME}/conf/setenv.sh
     fi
@@ -154,7 +183,7 @@ function retrieveStartCommand() {
     -Dkylin.flink.dependency=${flink_dependency} \
     -Dkylin.hadoop.conf.dir=${kylin_hadoop_conf_dir} \
     -Dkylin.server.host-address=${kylin_rest_address} \
-    -Dkylin.source.hive.warehouse-dir=${hiveWarehouseDir} \
+    -Dkylin.source.hive.warehouse-dir=${hive_warehouse_dir} \
     -Dspring.profiles.active=${spring_profile} \
     org.apache.hadoop.util.RunJar ${tomcat_root}/bin/bootstrap.jar  org.apache.catalina.startup.Bootstrap start"
 }
@@ -224,7 +253,7 @@ then
     echo "Check the log at ${KYLIN_HOME}/logs/kylin.log"
     echo "Web UI is at http://${kylin_rest_address_arr}/kylin"
     exit 0
-    
+
 # run command
 elif [ "$1" == "run" ]
 then

--- a/build/bin/kylin.sh
+++ b/build/bin/kylin.sh
@@ -39,37 +39,37 @@ function retrieveDependency() {
         echo "Using cached dependency..."
         source ${dir}/cached-hive-dependency.sh
         if [ -z "${hive_warehouse_dir}" ] || [ -z "${hive_dependency}" ] || [ -z "${hive_conf_path}" ]; then
-          echo "WARNING: Using ${dir}/cached-hive-dependency.sh error,will be use ${dir}/find-hive-dependency.sh"
+          echo "WARNING: Using ${dir}/cached-hive-dependency.sh failed,will be use ${dir}/find-hive-dependency.sh"
           source ${dir}/find-hive-dependency.sh
         fi
 
         source ${dir}/cached-hbase-dependency.sh
         if [ -z "${hbase_dependency}" ]; then
-          echo "WARNING: Using ${dir}/cached-hbase-dependency.sh error,will be use ${dir}/find-hbase-dependency.sh"
+          echo "WARNING: Using ${dir}/cached-hbase-dependency.sh failed,will be use ${dir}/find-hbase-dependency.sh"
           source ${dir}/find-hbase-dependency.sh
         fi
 
         source ${dir}/cached-hadoop-conf-dir.sh
         if [ -z "${kylin_hadoop_conf_dir}" ]; then
-          echo "WARNING: Using ${dir}/cached-hadoop-conf-dir.sh error,will be use ${dir}/find-hadoop-conf-dir.sh"
+          echo "WARNING: Using ${dir}/cached-hadoop-conf-dir.sh failed,will be use ${dir}/find-hadoop-conf-dir.sh"
           source ${dir}/find-hadoop-conf-dir.sh
         fi
 
         source ${dir}/cached-kafka-dependency.sh
         if [ -z "${kafka_dependency}" ]; then
-          echo "WARNING: Using ${dir}/cached-kafka-dependency.sh error,will be use ${dir}/find-kafka-dependency.sh"
+          echo "WARNING: Using ${dir}/cached-kafka-dependency.sh failed,will be use ${dir}/find-kafka-dependency.sh"
           source ${dir}/find-kafka-dependency.sh
         fi
 
         source ${dir}/cached-spark-dependency.sh
         if [ -z "${spark_dependency}" ]; then
-          echo "WARNING: Using ${dir}/cached-spark-dependency.sh error,will be use ${dir}/find-spark-dependency.sh"
+          echo "WARNING: Using ${dir}/cached-spark-dependency.sh failed,will be use ${dir}/find-spark-dependency.sh"
           source ${dir}/find-spark-dependency.sh
         fi
 
         source ${dir}/cached-flink-dependency.sh
         if [ -z "${flink_dependency}" ]; then
-          echo "WARNING: Using ${dir}/cached-flink-dependency.sh error,will be use ${dir}/find-flink-dependency.sh"
+          echo "WARNING: Using ${dir}/cached-flink-dependency.sh failed,will be use ${dir}/find-flink-dependency.sh"
           source ${dir}/find-flink-dependency.sh
         fi
     else

--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -716,7 +716,7 @@ public abstract class KylinConfigBase implements Serializable {
     public boolean isRowKeyEncodingAutoConvert() {
         return Boolean.parseBoolean(getOptional("kylin.cube.rowkey-encoding-auto-convert", "true"));
     }
-    
+
     public String getSegmentAdvisor() {
         return getOptional("kylin.cube.segment-advisor", "org.apache.kylin.cube.CubeSegmentAdvisor");
     }
@@ -1053,6 +1053,10 @@ public abstract class KylinConfigBase implements Serializable {
 
     public String getHiveDatabaseDir(String databaseName) {
         String dbDir = System.getProperty("kylin.source.hive.warehouse-dir");
+        if (StringUtils.isEmpty(dbDir)) {
+            logger.warn("kylin.source.hive.warehouse-dir is not set on system,now get it from kylin.properties and overwrites configuration.");
+            dbDir = getOptional("kylin.source.hive.warehouse-dir", "");
+        }
         if (!StringUtil.isEmpty(databaseName) && !databaseName.equalsIgnoreCase(DEFAULT)) {
             if (!dbDir.endsWith("/")) {
                 dbDir += "/";
@@ -2327,7 +2331,7 @@ public abstract class KylinConfigBase implements Serializable {
     public String getKylinMetricsEventTimeZone() {
         return getOptional("kylin.metrics.event-time-zone", getTimeZone()).toUpperCase(Locale.ROOT);
     }
-    
+
     public boolean isKylinMetricsMonitorEnabled() {
         return Boolean.parseBoolean(getOptional("kylin.metrics.monitor-enabled", FALSE));
     }

--- a/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -844,14 +844,16 @@ public abstract class KylinConfigBase implements Serializable {
 
     /**
      * get assigned server array, which a empty string array in default
+     *
      * @return
      */
     public String[] getAssignedServers() {
-        return getOptionalStringArray("kylin.cube.schedule.assigned-servers", new String[] {});
+        return getOptionalStringArray("kylin.cube.schedule.assigned-servers", new String[]{});
     }
 
     /**
      * Determine if the target node is in the assigned node
+     *
      * @param targetServers target task servers
      * @return
      */
@@ -1054,8 +1056,13 @@ public abstract class KylinConfigBase implements Serializable {
     public String getHiveDatabaseDir(String databaseName) {
         String dbDir = System.getProperty("kylin.source.hive.warehouse-dir");
         if (StringUtils.isEmpty(dbDir)) {
-            logger.warn("kylin.source.hive.warehouse-dir is not set on system,now get it from kylin.properties and overwrites configuration.");
+            logger.warn("get kylin.source.hive.warehouse-dir from system properties failed,now get it from overwrite configuration or kylin.properties");
             dbDir = getOptional("kylin.source.hive.warehouse-dir", "");
+        }
+        if (StringUtils.isEmpty(dbDir)) {
+            logger.info("get kylin.source.hive.warehouse-dir success: {}", dbDir)
+        } else {
+            logger.warn("get kylin.source.hive.warehouse-dir failed.")
         }
         if (!StringUtil.isEmpty(databaseName) && !databaseName.equalsIgnoreCase(DEFAULT)) {
             if (!dbDir.endsWith("/")) {


### PR DESCRIPTION
## Proposed changes

when using kylin 3.1.1's global dictionary, building the global dictionary failed because it could not be found "kylin.source.hive.warehouse-dir", resulting input path error.

After kylin is started for the first time, when it is started again,  ${dir}/cached-hive-dependency.sh will be used, now " kylin.source.hive.warehouse-dir" is not in cached-hive- dependency.sh, the parameter is null, causing a bug

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-4826), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
