### PR TITLE
KYLIN-4930 reset current page when searching for users/groups

### DIFF
--- a/webapp/app/js/controllers/userGroup.js
+++ b/webapp/app/js/controllers/userGroup.js
@@ -121,15 +121,19 @@ KylinApp
       });
     };
     $scope.listUsers = function (offset, limit) {
+      $scope.page.curpage = kylinConfig.page.offset
       $scope.getUserList(offset, limit, $scope.page);
     };
     $scope.listGroups = function (offset, limit) {
+      $scope.page.curpage = kylinConfig.page.offset
       $scope.getGroupList(offset, limit, $scope.page);
     };
     $scope.listEditUsers = function (offset, limit) {
+      $scope.editPage.curpage = kylinConfig.page.offset
       $scope.getUserList(offset, limit, $scope.editPage);
     };
     $scope.listEditGroups = function (offset, limit) {
+      $scope.editPage.curpage = kylinConfig.page.offset
       $scope.getGroupList(offset, limit, $scope.editPage);
     };
 


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-4930), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

The bug is caused by the current page not being reset, and it may exceeds the total number of pages of the search result.
