### PR TITLE
KYLIN-4967 Forbid to set 'spark.sql.adaptive.enabled' to true when building cube with Spark 2.X

### DIFF
--- a/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/utils/SparkVersionUtils.scala
+++ b/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/utils/SparkVersionUtils.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.apache.spark.utils
+
+import org.apache.spark.SPARK_VERSION
+
+object SparkVersionUtils {
+
+  /**
+   * Utility method to return the Spark Versions as float type
+   * and only return major version.
+   * SPARK_VERSION will be of format x.y.z e.g 2.4.7, 3.0.1,
+   * and return 2.4, 3.0
+   */
+  def getSparkVersionAsNumeric(): Float = {
+    val tmpArray = SPARK_VERSION.split("\\.")
+    // convert to float
+    if (tmpArray.length >= 2) {
+      (tmpArray(0) + "." + tmpArray(1)).toFloat
+    } else {
+      (tmpArray(0) + ".0").toFloat
+    }
+  }
+
+  /**
+   * This API ignores the sub-version and compares with only major version.
+   * Version passed should be of format x.y  e.g 2.2 ,2.3.
+   */
+  def isEqualToSparkVersion(targetVersion: String): Boolean = {
+    getSparkVersionAsNumeric == targetVersion.toFloat
+  }
+
+  /**
+   * This API ignores the sub-version and compares with only major version.
+   * Version passed should be of format x.y  e.g 2.2 ,2.3.
+   */
+  def isGreaterThanSparkVersion(targetVersion: String, isEqualTo: Boolean = false): Boolean = {
+    // compare the versions
+    if (isEqualTo) {
+      getSparkVersionAsNumeric >= targetVersion.toFloat
+    } else {
+      getSparkVersionAsNumeric > targetVersion.toFloat
+    }
+  }
+
+  /**
+   * This API ignores the sub-version and compares with only major version.
+   * Version passed should be of format x.y  e.g 2.2 ,2.3.
+   */
+  def isLessThanSparkVersion(targetVersion: String, isEqualTo: Boolean = false): Boolean = {
+    // compare the versions
+    if (isEqualTo) {
+      getSparkVersionAsNumeric <= targetVersion.toFloat
+    } else {
+      getSparkVersionAsNumeric < targetVersion.toFloat
+    }
+  }
+}

--- a/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/kylin/engine/spark/builder/CubeTableEncoder.scala
+++ b/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/kylin/engine/spark/builder/CubeTableEncoder.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.KylinFunctions._
 import org.apache.spark.sql.functions.{col, _}
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.utils.SparkVersionUtils
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable._
@@ -35,6 +36,10 @@ import scala.collection.mutable._
 object CubeTableEncoder extends Logging {
 
   def encodeTable(ds: Dataset[Row], seg: SegmentInfo, cols: util.Set[ColumnDesc]): Dataset[Row] = {
+    if (SparkVersionUtils.isLessThanSparkVersion("2.4", true)) {
+      assert(!ds.sparkSession.conf.get("spark.sql.adaptive.enabled", "false").toBoolean,
+        "Parameter 'spark.sql.adaptive.enabled' must be false when encode tables.")
+    }
     val structType = ds.schema
     var partitionedDs = ds
 

--- a/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/kylin/engine/spark/utils/Repartitioner.java
+++ b/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/kylin/engine/spark/utils/Repartitioner.java
@@ -154,7 +154,6 @@ public class Repartitioner {
             if (needRepartitionForShardByColumns()) {
                 logger.info("Cuboid[{}] repartition by column {} to {}", cuboid,
                         NSparkCubingUtil.getColumns(getShardByColumns())[0], repartitionNum);
-                //ss.sessionState().conf().setLocalProperty("spark.sql.adaptive.enabled", "false");
                 data = storage.getFrom(tempPath, ss).repartition(repartitionNum,
                         NSparkCubingUtil.getColumns(getShardByColumns()))
                         .sortWithinPartitions(sortCols);
@@ -166,9 +165,6 @@ public class Repartitioner {
             }
 
             storage.saveTo(path, data, ss);
-            //if (needRepartitionForShardByColumns()) {
-                //ss.sessionState().conf().setLocalProperty("spark.sql.adaptive.enabled", null);
-            //}
             if (readFileSystem.delete(tempResourcePath, true)) {
                 logger.info("Delete temp cuboid path successful. Temp path: {}.", tempPath);
             } else {

--- a/kylin-spark-project/kylin-spark-engine/src/test/scala/org/apache/kylin/engine/spark/builder/TestGlobalDictBuild.scala
+++ b/kylin-spark-project/kylin-spark-engine/src/test/scala/org/apache/kylin/engine/spark/builder/TestGlobalDictBuild.scala
@@ -106,14 +106,11 @@ class TestGlobalDictBuild extends SparderBaseFunSuite with SharedSparkSession wi
     val meta6 = buildDict(segInfo, seg, randomDataSet, dictColSet)
     Assert.assertEquals(280, meta6.getBucketSize)
     Assert.assertEquals(7600, meta6.getDictCount)
-    Assert.assertFalse(spark.conf.get("spark.sql.adaptive.enabled").toBoolean)
 
-    spark.conf.set("spark.sql.adaptive.enabled", true)
     randomDataSet = generateOriginData(dictCol, 2000, 26)
     val meta7 = buildDict(segInfo, seg, randomDataSet, dictColSet)
     Assert.assertEquals(280, meta7.getBucketSize)
     Assert.assertEquals(9600, meta7.getDictCount)
-    Assert.assertTrue(spark.conf.get("spark.sql.adaptive.enabled").toBoolean)
     DefaultScheduler.destroyInstance()
   }
 


### PR DESCRIPTION
## Proposed changes

With spark 2.X, when set 'spark.sql.adaptive.enabled' to true, it will impact the actually partition count when doing repartition with spark, which will lead to the wrong results for global dict and repartition by shardby column.

For example, after writing a cuboid data, kylin will repartition the cuboid data with 3 partition if need, but if 'spark.sql.adaptive.enabled' is true, spark will optimize the partition num to 1, which leads to wrong.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
