### PR TITLE
[KYLIN-4970]  fix spark.executor.extraJavaOptions args in SparkExecut…

### DIFF
--- a/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java
+++ b/engine-spark/src/main/java/org/apache/kylin/engine/spark/SparkExecutable.java
@@ -77,6 +77,8 @@ public class SparkExecutable extends AbstractExecutable {
     private static final String COUNTER_SAVE_AS = "CounterSaveAs";
     private static final String CONFIG_NAME = "configName";
 
+    private static final String EXECUTOR_JVM_ARG = "spark.executor.extraJavaOptions";
+
     public void setClassName(String className) {
         this.setParam(CLASS_NAME, className);
     }
@@ -289,8 +291,15 @@ public class SparkExecutable extends AbstractExecutable {
             }
 
             for (Map.Entry<String, String> entry : sparkConfs.entrySet()) {
-                stringBuilder.append(" --conf ").append(entry.getKey()).append("=").append(entry.getValue())
-                        .append(" ");
+                //"spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" need surround with "".
+                if (entry.getKey().equals(EXECUTOR_JVM_ARG)) {
+                    stringBuilder.append(" --conf ").append("\"").append(entry.getKey()).append("=")
+                            .append(entry.getValue()).append("\"").append(" ");
+                    logger.info("use spark.executor.extraJavaOptions: " + stringBuilder.toString());
+                } else {
+                    stringBuilder.append(" --conf ").append(entry.getKey()).append("=").append(entry.getValue())
+                            .append(" ");
+                }
             }
 
             stringBuilder.append("--jars %s %s %s");


### PR DESCRIPTION
…able.

## Proposed changes

in spark doc: spark.executor.extraJavaOption need surrond with "".

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
