### PR TITLE
KYLIN-5021 FilePruner throws NPE when there is no timePartitionColunm in cube

### DIFF
--- a/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
+++ b/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
@@ -295,7 +295,7 @@ class FilePruner(cubeInstance: CubeInstance,
   }
 
   private def getSegmentFilter(dataFilters: Seq[Expression], col: Attribute): Seq[Expression] = {
-    dataFilters.map(extractSegmentFilter(_, col)).filter(!_.equals(None)).map(_.get)
+    dataFilters.map(extractSegmentFilter(_, col)).filter(_.isDefined).map(_.get)
   }
 
   private def extractSegmentFilter(filter: Expression, col: Attribute): Option[Expression] = {

--- a/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
+++ b/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
@@ -299,6 +299,9 @@ class FilePruner(cubeInstance: CubeInstance,
   }
 
   private def extractSegmentFilter(filter: Expression, col: Attribute): Option[Expression] = {
+    if (col == null) {
+      return None
+    }
     filter match {
       case expressions.Or(left, right) =>
         val leftChild = extractSegmentFilter(left, col)
@@ -330,7 +333,7 @@ class FilePruner(cubeInstance: CubeInstance,
         }
       case _ =>
         //other unary filter like EqualTo, GreaterThan, GreaterThanOrEqual, etc.
-        if (col != null && filter.references.subsetOf(AttributeSet(col))) {
+        if (filter.references.subsetOf(AttributeSet(col))) {
           Some(filter)
         } else {
           None

--- a/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
+++ b/kylin-spark-project/kylin-spark-common/src/main/scala/org/apache/spark/sql/execution/datasource/FilePruner.scala
@@ -330,7 +330,7 @@ class FilePruner(cubeInstance: CubeInstance,
         }
       case _ =>
         //other unary filter like EqualTo, GreaterThan, GreaterThanOrEqual, etc.
-        if (filter.references.subsetOf(AttributeSet(col))) {
+        if (col != null && filter.references.subsetOf(AttributeSet(col))) {
           Some(filter)
         } else {
           None


### PR DESCRIPTION
## Proposed changes

JIRA:  https://issues.apache.org/jira/browse/KYLIN-5021

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

