### PR TITLE
[KYLIN-5032] Not allow change project for a cubeInstance.

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/controller/CubeController.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/controller/CubeController.java
@@ -861,6 +861,12 @@ public class CubeController extends BasicController {
                 return cubeRequest;
             }
 
+            if (!cube.getProject().equalsIgnoreCase(projectName)) {
+                String error = "Not allow change cube project!";
+                updateRequest(cubeRequest, false, error);
+                return cubeRequest;
+            }
+
             validateColumnFamily(desc);
 
             //cube renaming is not allowed


### PR DESCRIPTION
## Proposed changes
There are two project in Kylin: project1, project2.

Cube1 is in project1 now.

1.Some one is in project2 (In KYLIN-UI)

2.edit cube1 with url https://xxxx/kylin/cubes/edit/cube1

3. then save, now cube1 is in project2.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
