### PR TITLE
delete segment should disable the cube first

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/msg/Message.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/msg/Message.java
@@ -65,12 +65,16 @@ public class Message {
         return "Cannot delete segment '%s' as its status is not READY. Discard the on-going job for it.";
     }
 
-    public String getDELETE_READY_SEG_BY_UUID() {
-        return "Cannot delete segment by UUID '%s' as its status is READY or its Cube is READY.";
+    public String getDELETE_NOT_READY_SEG_BY_UUID() {
+        return "Cannot delete segment by UUID '%s' as its status is not READY. Discard the on-going job for it.";
     }
 
     public String getDELETE_SEG_FROM_READY_CUBE() {
         return "Cannot delete segment '%s' from ready cube '%s'. Please disable the cube first.";
+    }
+
+    public String getDELETE_SEG_FROM_READY_CUBE_BY_UUID() {
+        return "Cannot delete segment by UUID '%s' from ready cube '%s'. Please disable the cube first.";
     }
 
     public String getINVALID_BUILD_TYPE() {


### PR DESCRIPTION
## Proposed changes

Kylin recently release v3.1.2 , add a new feature KYLIN-4938( delete segment by UUID),  but the delete logic is not consistently with the Old logic: 
1. delete segment should disable the cube first
2. check OrphonSegment when segment is not in  READY status
 
This PR fix the problems above.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
