### PR TITLE
KYLIN-5044 When using beeline as hive cli refreshing lookup tables fails on NPE

### DIFF
--- a/source-hive/src/main/java/org/apache/kylin/source/hive/BeelineHiveClient.java
+++ b/source-hive/src/main/java/org/apache/kylin/source/hive/BeelineHiveClient.java
@@ -244,7 +244,7 @@ public class BeelineHiveClient implements IHiveClient {
 
     private void parseResultEntry(ResultSet resultSet, HiveTableMetaBuilder builder) throws SQLException {
         List<HiveTableMeta.HiveTableColumnMeta> partitionColumns = Lists.newArrayList();
-        if ("# Partition Information".equals(resultSet.getString(1).trim())) {
+        if ("# Partition Information".equals(resultSet.getString(1).trim())) { // TODO: this should also be updated
             resultSet.next();
             Preconditions.checkArgument("# col_name".equals(resultSet.getString(1).trim()));
             resultSet.next();
@@ -259,10 +259,10 @@ public class BeelineHiveClient implements IHiveClient {
             builder.setPartitionColumns(partitionColumns);
         }
 
-        if ("Owner:".equals(resultSet.getString(1).trim())) {
+        if ("Owner".equals(resultSet.getString(1).trim())) {
             builder.setOwner(resultSet.getString(2).trim());
         }
-        if ("LastAccessTime:".equals(resultSet.getString(1).trim())) {
+        if ("Last Access".equals(resultSet.getString(1).trim())) {
             try {
                 int i = Integer.parseInt(resultSet.getString(2).trim());
                 builder.setLastAccessTime(i);
@@ -270,19 +270,19 @@ public class BeelineHiveClient implements IHiveClient {
                 builder.setLastAccessTime(0);
             }
         }
-        if ("Location:".equals(resultSet.getString(1).trim())) {
+        if ("Location".equals(resultSet.getString(1).trim())) {
             builder.setSdLocation(resultSet.getString(2).trim());
         }
-        if ("Table Type:".equals(resultSet.getString(1).trim())) {
+        if ("Type".equals(resultSet.getString(1).trim())) {
             builder.setTableType(resultSet.getString(2).trim());
         }
-        if ("Table Parameters:".equals(resultSet.getString(1).trim())) {
+        if ("Table Properties".equals(resultSet.getString(1).trim())) {
             extractTableParam(resultSet, builder);
         }
-        if ("InputFormat:".equals(resultSet.getString(1).trim())) {
+        if ("InputFormat".equals(resultSet.getString(1).trim())) {
             builder.setSdInputFormat(resultSet.getString(2).trim());
         }
-        if ("OutputFormat:".equals(resultSet.getString(1).trim())) {
+        if ("OutputFormat".equals(resultSet.getString(1).trim())) {
             builder.setSdOutputFormat(resultSet.getString(2).trim());
         }
     }
@@ -316,7 +316,6 @@ public class BeelineHiveClient implements IHiveClient {
     }
 
     public static void main(String[] args) throws SQLException {
-
         BeelineHiveClient loader = new BeelineHiveClient(
                 "-n root --hiveconf hive.security.authorization.sqlstd.confwhitelist.append='mapreduce.job.*|dfs.*' -u 'jdbc:hive2://sandbox:10000'");
         //BeelineHiveClient loader = new BeelineHiveClient(StringUtils.join(args, " "));

--- a/source-hive/src/main/java/org/apache/kylin/source/hive/BeelineHiveClient.java
+++ b/source-hive/src/main/java/org/apache/kylin/source/hive/BeelineHiveClient.java
@@ -244,7 +244,7 @@ public class BeelineHiveClient implements IHiveClient {
 
     private void parseResultEntry(ResultSet resultSet, HiveTableMetaBuilder builder) throws SQLException {
         List<HiveTableMeta.HiveTableColumnMeta> partitionColumns = Lists.newArrayList();
-        if ("# Partition Information".equals(resultSet.getString(1).trim())) { // TODO: this should also be updated
+        if ("# Partition Information".equals(resultSet.getString(1).trim())) {
             resultSet.next();
             Preconditions.checkArgument("# col_name".equals(resultSet.getString(1).trim()));
             resultSet.next();


### PR DESCRIPTION
See more information in jira: https://issues.apache.org/jira/browse/KYLIN-5044

When using beeline as hive cli refreshing lookup tables fails on NPE - no metadata is fetched. In beeline `DESCRIBE EXTENDED <table>` returns
```
# Detailed Table Information||
Database|default|
Table|orders|
Owner|root|
Created Time|Mon Jul 19 04:12:18 EDT 2021|
Last Access|Wed Dec 31 19:00:00 EST 1969|
Created By|Spark 2.2 or prior|
Type|MANAGED|
Provider|hive|
Table Properties|[transient_lastDdlTime=1626682338]|
Statistics|173452161 bytes|
Location|hdfs://server:8020/user/root/tpch/orders|
Serde Library|org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe|
InputFormat|org.apache.hadoop.mapred.TextInputFormat|
OutputFormat|org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat|
Storage Properties|[line.delim=, field.delim=|, serialization.format=|]|
Partition Provider|Catalog|
```
Attribute names are different than expected by the code.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
