### PR TITLE
KYLIN-5054 kylin_system's project and cubes create time is wrong 1970

### DIFF
--- a/tool/src/main/java/org/apache/kylin/tool/metrics/systemcube/CubeInstanceCreator.java
+++ b/tool/src/main/java/org/apache/kylin/tool/metrics/systemcube/CubeInstanceCreator.java
@@ -78,7 +78,7 @@ public class CubeInstanceCreator {
         cubeInstance.setDescName(tableName.replace('.', '_'));
         cubeInstance.setStatus(RealizationStatusEnum.DISABLED);
         cubeInstance.setOwner(owner);
-        cubeInstance.setCreateTimeUTC(0L);
+        cubeInstance.setCreateTimeUTC(System.currentTimeMillis());
         cubeInstance.updateRandomUuid();
 
         return cubeInstance;

--- a/tool/src/main/java/org/apache/kylin/tool/metrics/systemcube/ProjectCreator.java
+++ b/tool/src/main/java/org/apache/kylin/tool/metrics/systemcube/ProjectCreator.java
@@ -47,7 +47,7 @@ public class ProjectCreator {
         projectInstance.setOwner(owner);
         projectInstance.setDescription(SYSTEM_PROJECT_DESC);
         projectInstance.setStatus(ProjectStatusEnum.ENABLED);
-        projectInstance.setCreateTimeUTC(0L);
+        projectInstance.setCreateTimeUTC(System.currentTimeMillis());
         projectInstance.updateRandomUuid();
 
         if (kylinTables != null)


### PR DESCRIPTION
## Proposed changes

Kylin_System's project and cubes create time is wrong (1970 ). It should be based on the current time when the user set up the Kylin_System project.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X ] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [X ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [X ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] If this change need a document change, I will prepare another pr against the `document` branch
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin or dev@kylin by explaining why you chose the solution you did and what alternatives you considered, etc...
