### PR TITLE
KYLIN-5183 customize or get query id for devops

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/QueryContext.java
+++ b/core-common/src/main/java/org/apache/kylin/common/QueryContext.java
@@ -52,7 +52,7 @@ public class QueryContext {
 
     private long queryStartMillis;
 
-    private final String queryId;
+    private String queryId;
     private String username;
     private Set<String> groups;
     private String project;
@@ -100,6 +100,10 @@ public class QueryContext {
         if (Thread.interrupted()) {
             throw new KylinTimeoutException("Query timeout");
         }
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
     }
 
     public String getQueryId() {

--- a/core-common/src/main/java/org/apache/kylin/common/debug/BackdoorToggles.java
+++ b/core-common/src/main/java/org/apache/kylin/common/debug/BackdoorToggles.java
@@ -401,4 +401,9 @@ public class BackdoorToggles {
     public final static String DEBUG_TOGGLE_HIT_CUBE = "DEBUG_TOGGLE_HIT_CUBE";
 
     public final static String DEBUG_TOGGLE_SPARK_POOL = "DEBUG_TOGGLE_SPARK_POOL";
+
+    /**
+     * user customize query id
+     */
+    public final static String CUSTOMIZE_QUERY_ID = "CUSTOMIZE_QUERY_ID";
 }

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/IRemoteClient.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/IRemoteClient.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.apache.kylin.jdbc;
 
@@ -31,10 +31,21 @@ public interface IRemoteClient extends Closeable {
     class QueryResult {
         public final List<ColumnMetaData> columnMeta;
         public final Iterable<Object> iterable;
+        public String queryId;
+
+        public String getQueryId() {
+            return queryId;
+        }
 
         public QueryResult(List<ColumnMetaData> columnMeta, Iterable<Object> iterable) {
             this.columnMeta = columnMeta;
             this.iterable = iterable;
+        }
+
+        public QueryResult(List<ColumnMetaData> columnMeta, Iterable<Object> iterable, String queryId) {
+            this.columnMeta = columnMeta;
+            this.iterable = iterable;
+            this.queryId = queryId;
         }
     }
 

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinClient.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinClient.java
@@ -314,7 +314,7 @@ public class KylinClient implements IRemoteClient {
             List<KMetaCatalog> catalogs = convertMetaCatalogs(schemas);
             return new KMetaProject(project, catalogs);
         } finally {
-           get.releaseConnection(); 
+           get.releaseConnection();
         }
     }
 
@@ -406,7 +406,7 @@ public class KylinClient implements IRemoteClient {
         List<ColumnMetaData> metas = convertColumnMeta(queryResp);
         List<Object> data = convertResultData(queryResp, metas);
 
-        return new QueryResult(metas, data);
+        return new QueryResult(metas, data, queryResp.getQueryId());
     }
 
     private List<StatementParameter> convertParameters(List<Object> paramValues) {

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinResultSet.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinResultSet.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,16 @@ import org.apache.calcite.avatica.QueryState;
 import org.apache.kylin.jdbc.IRemoteClient.QueryResult;
 
 public class KylinResultSet extends AvaticaResultSet {
+
+    private String queryId;
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
+    }
 
     public KylinResultSet(AvaticaStatement statement, QueryState state, Signature signature, ResultSetMetaData resultSetMetaData, TimeZone timeZone, Frame firstFrame) throws SQLException {
         super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
@@ -71,6 +81,7 @@ public class KylinResultSet extends AvaticaResultSet {
         QueryResult result;
         try {
             result = client.executeQuery(sql, paramValues, queryToggles);
+            this.setQueryId(result.getQueryId());
         } catch (IOException e) {
             throw new SQLException(e);
         }
@@ -91,6 +102,9 @@ public class KylinResultSet extends AvaticaResultSet {
         for (String key : connProps.stringPropertyNames()) {
             if (Driver.CLIENT_CALCITE_PROP_NAMES.contains(key)) {
                 props.put(key, connProps.getProperty(key));
+            }
+            if (key.startsWith("CUSTOMIZE_")) {
+                queryToggles.put(key, connProps.getProperty(key));
             }
         }
 

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/json/SQLResponseStub.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/json/SQLResponseStub.java
@@ -58,6 +58,8 @@ public class SQLResponseStub implements Serializable {
 
     private boolean storageCacheUsed = false;
 
+    private String queryId;
+
     public SQLResponseStub() {
     }
 
@@ -151,6 +153,14 @@ public class SQLResponseStub implements Serializable {
 
     public void setStorageCacheUsed(boolean storageCacheUsed) {
         this.storageCacheUsed = storageCacheUsed;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/server-base/src/main/java/org/apache/kylin/rest/response/SQLResponse.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/response/SQLResponse.java
@@ -97,6 +97,8 @@ public class SQLResponse implements Serializable {
 
     private List<SQLResponseTrace> traces;
 
+    protected String queryId;
+
     public SQLResponse() {
     }
 
@@ -304,6 +306,14 @@ public class SQLResponse implements Serializable {
 
     public List<SQLResponseTrace> getTraces() {
         return traces;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
     }
 
     @JsonIgnore

--- a/server-base/src/main/java/org/apache/kylin/rest/service/QueryService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/QueryService.java
@@ -446,6 +446,10 @@ public class QueryService extends BasicService {
             BackdoorToggles.addToggles(sqlRequest.getBackdoorToggles());
         }
 
+        if (sqlRequest.getBackdoorToggles() != null && !StringUtil.isEmpty(sqlRequest.getBackdoorToggles().get(BackdoorToggles.CUSTOMIZE_QUERY_ID))) {
+            queryContext.setQueryId(sqlRequest.getBackdoorToggles().get(BackdoorToggles.CUSTOMIZE_QUERY_ID));
+        }
+
         try (SetThreadName ignored = new SetThreadName("Query %s", queryContext.getQueryId())) {
             // force clear the query context before a new query
             OLAPContext.clearThreadLocalContexts();
@@ -484,7 +488,7 @@ public class QueryService extends BasicService {
                     sqlResponse = queryAndUpdateCache(sqlRequest, isQueryCacheEnabled);
                 }
             }
-
+            sqlResponse.setQueryId(queryContext.getQueryId());
             sqlResponse.setDuration(queryContext.getAccumulatedMillis());
             if (QuerySparkMetrics.getInstance().getQueryExecutionMetrics(queryContext.getQueryId()) != null) {
                 String sqlTraceUrl = SparderContext.appMasterTrackURL() + "/SQL/execution/?id=" +

--- a/server-base/src/test/java/org/apache/kylin/rest/response/SQLResponseTest.java
+++ b/server-base/src/test/java/org/apache/kylin/rest/response/SQLResponseTest.java
@@ -36,7 +36,7 @@ public class SQLResponseTest {
                 "realizationTypes", "affectedRowCount", "isException",
                 "exceptionMessage", "duration", "partial", "totalScanCount", "hitExceptionCache",
                 "storageCacheUsed", "sparkPool", "pushDown", "traceUrl", "totalScanBytes",
-                "totalScanFiles", "metadataTime", "totalSparkScanTime", "traces"};
+                "totalScanFiles", "metadataTime", "totalSparkScanTime", "traces", "queryId"};
 
         SQLResponse sqlResponse = new SQLResponse(null, null, "learn_cube", 100, false, null, false, false);
         String jsonStr = JsonUtil.writeValueAsString(sqlResponse);


### PR DESCRIPTION
## Proposed changes

When there is a problem with the query, due to the large amount of queries at the same time, many query IDs are generated, but the query results are not returned, and the specific ID cannot be accurately located, which increases the problem location and operation and maintenance costs.
Now you can get or set any query id when you want justing using 'CUSTOMIZE_QUERY_ID' in you requset or connect property when you connect the kylin to query 



        Properties info= new Properties();
        info.put("user","ADMIN");
        info.put("password","KYLIN");
        info.put("CUSTOMIZE_QUERY_ID","test_query_id_"+System.currentTimeMillis());
        Connection conn= driver.connect("jdbc:kylin://",info);


## Github Branch 

Kylin 4 or main

## Types of changes

- [x] New feature (get or set query id)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-5183), and have described the feature there in detail
- [x] Commit messages in my PR start with the related jira ID [KYLIN-5183]
- [x] Compiling and unit tests pass locally with my changes
- [x] Any dependent changes have been merged

## Further comments

People can get or customize any query id when them need,and the query id will help them to find problem if the query is error.

