### PR TITLE
KYLIN-5180 Repair the dictionary lock bug when multi job building

### DIFF
--- a/core-dictionary/src/main/java/org/apache/kylin/dict/GlobalDictionaryBuilder.java
+++ b/core-dictionary/src/main/java/org/apache/kylin/dict/GlobalDictionaryBuilder.java
@@ -59,12 +59,11 @@ public class GlobalDictionaryBuilder implements IDictionaryBuilder {
             lock.lock(lockPath, Long.MAX_VALUE);
             this.builder = new AppendTrieDictionaryBuilder(baseDir, maxEntriesPerSlice, true);
         } catch (Throwable e) {
-            throw new RuntimeException(
-                    String.format(Locale.ROOT, "Failed to create global dictionary on %s ", sourceColumn), e);
-        } finally {
             if (lock.isLockedByMe(lockPath)) {
                 lock.unlock(lockPath);
             }
+            throw new RuntimeException(
+                    String.format(Locale.ROOT, "Failed to create global dictionary on %s ", sourceColumn), e);
         }
         this.baseId = baseId;
     }


### PR DESCRIPTION
## Proposed changes

fix the dictionary lock 


## Github Branch 

kylin3


## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist


- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-5180), and have described the bug there in detail
- [x] Commit messages in my PR start with the related jira ID
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged

## Further comments

multi cube job building will be ok
