### PR TITLE
[KYLIN-5215] Fix  Kylin pushdown query and Cube query is inconsistent

### DIFF
--- a/kylin-spark-project/kylin-spark-query/src/main/java/org/apache/kylin/query/pushdown/PushDownRunnerSparkImpl.java
+++ b/kylin-spark-project/kylin-spark-query/src/main/java/org/apache/kylin/query/pushdown/PushDownRunnerSparkImpl.java
@@ -50,7 +50,7 @@ public class PushDownRunnerSparkImpl extends AbstractPushdownRunner {
         for (int i = 0; i < columnCount; ++i) {
             int nullable = fieldList.get(i).isNullable() ? 1 : 0;
             columnMetas.add(new SelectedColumnMeta(false, false, false, false, nullable, true, Integer.MAX_VALUE,
-                    fieldList.get(i).getName().toUpperCase(Locale.ROOT), fieldList.get(i).getName().toUpperCase(Locale.ROOT), null, null,
+                    fieldList.get(i).getName(), fieldList.get(i).getName(), null, null,
                     null, fieldList.get(i).getPrecision(), fieldList.get(i).getScale(), fieldList.get(i).getDataType(),
                     fieldList.get(i).getDataTypeName(), false, false, false));
         }


### PR DESCRIPTION
Fix columnMetas information returned by Kylin pushdown query and Cube query is inconsistent
## Proposed changes
1. Delete toUpperCase  from  PushDownRunnerSparkImpl.executeQuery 

`            columnMetas.add(new SelectedColumnMeta(false, false, false, false, nullable, true, Integer.MAX_VALUE,
                    fieldList.get(i).getName().toUpperCase(Locale.ROOT), fieldList.get(i).getName().toUpperCase(Locale.ROOT), null, null,
                    null, fieldList.get(i).getPrecision(), fieldList.get(i).getScale(), fieldList.get(i).getDataType(),
                    fieldList.get(i).getDataTypeName(), false, false, false));`
## Checklist
-  I have create an issue on [Kylin's jira](https://issues.apache.org/jira/projects/KYLIN/issues/KYLIN-5215), and have described the bug/feature there in detail


