### PR TITLE
KYLIN-5228 Fixed length limitation during loading properties to Kylin config in Kylin5.0

### DIFF
--- a/src/core-common/src/main/java/org/apache/kylin/common/KylinExternalConfigLoader.java
+++ b/src/core-common/src/main/java/org/apache/kylin/common/KylinExternalConfigLoader.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -152,8 +151,12 @@ public class KylinExternalConfigLoader implements IExternalConfigLoader {
     @Override
     public String getConfig() {
         StringWriter writer = new StringWriter();
-        properties.list(new PrintWriter(writer));
-        return writer.toString();
+        try {
+            properties.store(writer, "");
+        } catch (IOException e) {
+            throw new KylinException(UNKNOWN_ERROR_CODE, e);
+        }
+        return writer.getBuffer().toString();
     }
 
     @Override

--- a/src/core-common/src/test/java/org/apache/kylin/common/TestExternalConfigLoader.java
+++ b/src/core-common/src/test/java/org/apache/kylin/common/TestExternalConfigLoader.java
@@ -18,9 +18,13 @@
 
 package org.apache.kylin.common;
 
-import java.io.PrintWriter;
+import static org.apache.kylin.common.exception.CommonErrorCode.UNKNOWN_ERROR_CODE;
+
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Properties;
+
+import org.apache.kylin.common.exception.KylinException;
 
 import io.kyligence.config.core.loader.IExternalConfigLoader;
 
@@ -34,8 +38,12 @@ public class TestExternalConfigLoader implements IExternalConfigLoader {
     @Override
     public String getConfig() {
         StringWriter writer = new StringWriter();
-        properties.list(new PrintWriter(writer));
-        return writer.toString();
+        try {
+            properties.store(writer, "");
+        } catch (IOException e) {
+            throw new KylinException(UNKNOWN_ERROR_CODE, e);
+        }
+        return writer.getBuffer().toString();
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Currently we use properties.list() to get kylin config from properties to string, but this method results in a maximum length limit (which is set as 37 )for each properties. We can leverage the properties.store() method

## Github Branch 

As most of the development works are on Kylin 4, we need to switch it as main branch. Apache Kylin community changes the branch settings on Github since 2021-08-04 :

1. The default branch _main_ is for **Kylin 4.x** (Parquet storage);
2. The original branch _master_ for **Kylin 3.x** (HBase storage) has been renamed to **kylin3** ;

Please check [Intro to Kylin 4 architecture](https://kylin.apache.org/blog/2021/07/02/Apache-Kylin4-A-new-storage-and-compute-architecture/) and [INFRA-22166](https://issues.apache.org/jira/browse/INFRA-22166) if you are interested.

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have create an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-5228), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-5228 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
