### PR TITLE
KYLIN-5245 fix incorrect job status is displayed when deployMode is c…

### DIFF
--- a/kylin-spark-project/kylin-spark-engine/src/main/java/org/apache/kylin/engine/spark/application/SparkEntry.java
+++ b/kylin-spark-project/kylin-spark-engine/src/main/java/org/apache/kylin/engine/spark/application/SparkEntry.java
@@ -22,6 +22,15 @@ import org.apache.spark.application.JobWorkSpace;
 
 public class SparkEntry {
     public static void main(String[] args) {
-        JobWorkSpace.execute(args);
+        int retCode = JobWorkSpace.execute(args);
+        if (retCode == 2) {
+            System.exit(1);
+        } else if (System.getProperty("spark.master").equals("yarn") && System.getProperty("spark.submit.deployMode").equals("cluster")) {
+            if (retCode == 1) {
+                throw new RuntimeException("Job failed!");
+            }
+        } else {
+            System.exit(retCode);
+        }
     }
 }

--- a/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
+++ b/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
@@ -28,22 +28,18 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.KylinJobEventLoop
 
 object JobWorkSpace extends Logging {
-  def execute(args: Array[String]): Unit = {
+  def execute(args: Array[String]): Int = {
     try {
       val (application, appArgs) = resolveArgs(args)
       val eventLoop = new KylinJobEventLoop
       val worker = new JobWorker(application, appArgs, eventLoop)
       val monitor = new JobMonitor(eventLoop)
       val workspace = new JobWorkSpace(eventLoop, monitor, worker)
-      if (System.getProperty("spark.master").equals("yarn") && System.getProperty("spark.submit.deployMode").equals("cluster")) {
-        workspace.run()
-      } else {
-        System.exit(workspace.run())
-      }
+      workspace.run()
     } catch {
       case throwable: Throwable =>
         logError("Error occurred when init job workspace.", throwable)
-        System.exit(1)
+        2
     }
   }
 


### PR DESCRIPTION
## Proposed changes

修复在kylin4中当以 spark.master=yarn，spark.submit.deployMode=cluster 提交build job，如在job执行中发生异常，然而最终显示的job状态却为success。我发现问题主要出在org.apache.spark.application.JobWorkSpace 上：
org.apache.spark.application.JobWorkSpace#execute 调用 run 方法，run 方法中会调用 eventLoop.post(RunJob())，JobWorker 在收到  RunJob 后会执行它的 execute() 方法，execute() 方法执行中发生异常会在catche 异常后调用eventLoop.post(UnknownThrowable(exception))，而 JobMonitor 在收到 UnknownThrowable 后会调用eventLoop.post(JobFailed("Unknown error occurred during the job.", ur.throwable))，JobWorkSpace 在 eventLoop 中注册的监听用于”JobSucceeded“、”JobFailed“ 处理，其中对 JobFailed 事件的处理仅是将 statusCode=1，所以 SparkEntry的main方法会正常结束，job server 的 CliCommandExecutor 获取到process退出码0，错误认为作业运行成功

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [x] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
