### PR TITLE
KYLIN-5279 Add default null collation configuration with CalciteExtrasProperties for Kylin5.0 

### DIFF
--- a/src/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/src/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -1723,10 +1723,6 @@ public abstract class KylinConfigBase implements Serializable {
         return Boolean.parseBoolean(getOptional("kylin.query.replace-count-column-with-count-star", FALSE));
     }
 
-    public boolean isAscOrderNullFirstEnable() {
-        return Boolean.parseBoolean(getOptional("kylin.query.asc-order-null-first-enable", FALSE));
-    }
-
     // Select star on large table is too slow for BI, add limit by default if missing
     // https://issues.apache.org/jira/browse/KYLIN-2649
     public int getForceLimit() {

--- a/src/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/src/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -1723,6 +1723,10 @@ public abstract class KylinConfigBase implements Serializable {
         return Boolean.parseBoolean(getOptional("kylin.query.replace-count-column-with-count-star", FALSE));
     }
 
+    public boolean isAscOrderNullFirstEnable() {
+        return Boolean.parseBoolean(getOptional("kylin.query.asc-order-null-first-enable", FALSE));
+    }
+
     // Select star on large table is too slow for BI, add limit by default if missing
     // https://issues.apache.org/jira/browse/KYLIN-2649
     public int getForceLimit() {

--- a/src/query-common/src/main/java/org/apache/kylin/query/engine/KECalciteConfig.java
+++ b/src/query-common/src/main/java/org/apache/kylin/query/engine/KECalciteConfig.java
@@ -53,7 +53,7 @@ public class KECalciteConfig extends CalciteConnectionConfigImpl {
 
     @Override
     public NullCollation defaultNullCollation() {
-        return NullCollation.LOW;
+        return NullCollation.HIGH;
     }
 
     @Override

--- a/src/query-common/src/main/java/org/apache/kylin/query/engine/KECalciteConfig.java
+++ b/src/query-common/src/main/java/org/apache/kylin/query/engine/KECalciteConfig.java
@@ -53,7 +53,7 @@ public class KECalciteConfig extends CalciteConnectionConfigImpl {
 
     @Override
     public NullCollation defaultNullCollation() {
-        return NullCollation.HIGH;
+        return kylinConfig.isAscOrderNullFirstEnable() ? NullCollation.LOW : NullCollation.HIGH;
     }
 
     @Override

--- a/src/query-common/src/main/java/org/apache/kylin/query/engine/KECalciteConfig.java
+++ b/src/query-common/src/main/java/org/apache/kylin/query/engine/KECalciteConfig.java
@@ -53,7 +53,22 @@ public class KECalciteConfig extends CalciteConnectionConfigImpl {
 
     @Override
     public NullCollation defaultNullCollation() {
-        return kylinConfig.isAscOrderNullFirstEnable() ? NullCollation.LOW : NullCollation.HIGH;
+        String nullCollation = kylinConfig.getCalciteExtrasProperties.get("defaultNullCollation");
+        if (null == nullCollation) {
+            return NullCollation.HIGH;
+        }
+        switch (nullCollation.toLowerCase(Locale.ROOT)) {
+            case "low":
+                return NullCollation.LOW;
+            case "high":
+                return NullCollation.HIGH;
+            case "first":
+                return NullCollation.FIRST;
+            case "last":
+                return NullCollation.LAST;
+            default:
+                throw new UnsupportedOperationException("unsupported null collation type: " + nullCollation);
+        }
     }
 
     @Override


### PR DESCRIPTION
according to pgsql: https://www.postgresql.org/docs/current/queries-order.html

By default, null values sort as if larger than any non-null value; that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [ ] Branch **kylin4** for v4.x
- [x] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-5279 Default null collation for Kylin5.0 sqls should be null-last for ASC order and null-first for DESC order."
- [x] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

