### PR TITLE
KYLIN-5285 the number of filePartitions of FileScanRDD when used shardby

### DIFF
--- a/kylin-spark-project/kylin-spark-common/src/main/spark31/org/apache/spark/sql/execution/KylinFileSourceScanExec.scala
+++ b/kylin-spark-project/kylin-spark-common/src/main/spark31/org/apache/spark/sql/execution/KylinFileSourceScanExec.scala
@@ -162,9 +162,12 @@ class KylinFileSourceScanExec(
         f => FilePruner.getPartitionId(new Path(f.filePath))
       }
 
-    val filePartitions = Seq.tabulate(shardSpec.numShards) { shardId =>
-      FilePartition(shardId, filesToPartitionId.getOrElse(shardId, Nil).toArray)
-    }
+    var shardId = 0
+    val filePartitions = new ArrayBuffer[FilePartition]()
+    filesToPartitionId.foreach(t => {
+      filePartitions += FilePartition(shardId, t._2.toArray)
+      shardId += 1
+    })
 
     if (SoftAffinityManager.usingSoftAffinity) {
       val start = System.currentTimeMillis()

--- a/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
+++ b/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
@@ -35,15 +35,7 @@ object JobWorkSpace extends Logging {
       val worker = new JobWorker(application, appArgs, eventLoop)
       val monitor = new JobMonitor(eventLoop)
       val workspace = new JobWorkSpace(eventLoop, monitor, worker)
-
-      if (System.getProperty("spark.master").equals("yarn") && System.getProperty("spark.submit.deployMode").equals("cluster")) {
-        val res = workspace.run()
-        if (res != 0) {
-          System.exit(res)
-        }
-      } else {
-        System.exit(workspace.run())
-      }
+      workspace.run()
     } catch {
       case throwable: Throwable =>
         logError("Error occurred when init job workspace.", throwable)


### PR DESCRIPTION
## Proposed changes

当查询满足shardby条件，在创建 FileScanRDD 时，FilePartition 数应由 shardby 裁剪后的数据文件确定，而不是由回答当前查询的cuboid下所有文件确定。

before apply patch:
![75f05254505233fb607cb082a6c5331](https://user-images.githubusercontent.com/49258176/198923649-8f2195fe-999c-4d9b-ae13-2a01266ee8d4.jpg)
![6ad28bbbf6185896ebebaba241c2c44](https://user-images.githubusercontent.com/49258176/198923660-2747d2a2-b949-4a3d-a645-c7f796d9009b.jpg)
![753a890c47adf4b5d2dd045acf16688](https://user-images.githubusercontent.com/49258176/198923672-83ad49b1-2327-49cd-ae51-c3b923944edb.jpg)

after apply patch:
![6668ce58d0fd4bfad491e855e8ba196](https://user-images.githubusercontent.com/49258176/198923698-f4935194-6205-48fe-8b78-ed6caea43626.jpg)
![79590990a30b061f57174306968d6d3](https://user-images.githubusercontent.com/49258176/198923710-1c203592-8057-4073-a709-431675532e3e.jpg)
![ccff12e72b968071b0565ad74178b06](https://user-images.githubusercontent.com/49258176/198923719-9dc2401f-35a3-4eb2-8610-5e9504a9b0db.jpg)

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [x] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
