### PR TITLE
KYLIN-5246 long running job's log staying in mem, may cause job serve…

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/CliCommandExecutor.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/CliCommandExecutor.java
@@ -143,9 +143,7 @@ public class CliCommandExecutor {
             BufferedReader reader = new BufferedReader(
                     new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8));
             String line;
-            StringBuilder result = new StringBuilder();
             while ((line = reader.readLine()) != null && !Thread.currentThread().isInterrupted()) {
-                result.append(line).append('\n');
                 if (logAppender != null) {
                     logAppender.log(line);
                 }
@@ -164,7 +162,8 @@ public class CliCommandExecutor {
 
             try {
                 int exitCode = proc.waitFor();
-                return Pair.newPair(exitCode, result.toString());
+                String msg = exitCode !=0 ? "Job execute failed, see kylin log or spark log for more info." : "success";
+                return Pair.newPair(exitCode, msg);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IOException(e);


### PR DESCRIPTION
…r oom.

## Proposed changes

long running job's log staying in mem, may cause job server oom.

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [x] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
