### PR TITLE
KYLIN-5246 long running job's log staying in mem, may cause job serve…

### DIFF
--- a/core-common/src/main/java/org/apache/kylin/common/util/RingBuffer.java
+++ b/core-common/src/main/java/org/apache/kylin/common/util/RingBuffer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.common.util;
+
+/**
+ * @author zhaoliu4
+ * @date 2022/11/3
+ */
+public class RingBuffer {
+    private final byte[] bytes;
+
+    /**
+     * next write position
+     */
+    private int writePos;
+
+    /**
+     * number of bytes has stored
+     */
+    private int size;
+
+    private RingBuffer(int capacity) {
+        this.bytes = new byte[capacity];
+    }
+
+    public static RingBuffer allocate(int capacity) {
+        return new RingBuffer(capacity);
+    }
+
+    public RingBuffer put(byte[] src) {
+        for (int i = 0; i < src.length; i++) {
+            if (writePos >= bytes.length) {
+                // reset, turn back continue to write
+                writePos = 0;
+            }
+            bytes[writePos++] = src[i];
+            size = size < bytes.length ? size + 1 : size;
+        }
+        return this;
+    }
+
+    public byte[] get() {
+        byte[] res;
+        if (size == bytes.length && writePos < size) {
+            // occur turn back
+            res = new byte[size];
+            System.arraycopy(bytes, writePos, res, 0, size - writePos);
+            System.arraycopy(bytes, 0, res, size - writePos, writePos);
+        } else {
+            res = new byte[writePos];
+            System.arraycopy(bytes, 0, res, 0, writePos);
+        }
+        return res;
+    }
+}

--- a/core-common/src/test/java/org/apache/kylin/common/util/RingBufferTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/util/RingBufferTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kylin.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author zhaoliu4
+ * @date 2022/11/9
+ */
+public class RingBufferTest {
+    @Test
+    public void test() throws IOException {
+        String log1 = "2022-11-09 18:25:48,678 INFO  [task-result-getter-0] scheduler.TaskSetManager:54 : Starting task 0.0 in stage 384.0 (TID 621, kylin-hadoop-001, executor 7, partition 0, NODE_LOCAL, 7780 bytes)\n";
+        String log2 = "2022-11-09 18:25:48,678 INFO  [dispatcher-event-loop-26] spark.MapOutputTrackerMasterEndpoint:54 : Asked to send map output locations for shuffle 138 to x.x.x.x:46334\n";
+        String log3 = "2022-11-09 18:25:48,689 INFO  [task-result-getter-0] scheduler.TaskSetManager:54 : Finished task 0.0 in stage 384.0 (TID 621) in 31 ms on kylin-hadoop-001 (executor 7) (1/1)\n";
+        String log4 = "2022-11-09 18:25:48,689 INFO  [task-result-getter-0] cluster.YarnScheduler:54 : Removed TaskSet 384.0, whose tasks have all completed, from pool vip_tasks\n";
+
+        // mock yarn application log input stream
+        byte[] logBytes = (log1 + log2 + log3 + log4).getBytes(StandardCharsets.UTF_8);
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(logBytes)))) {
+            String line = null;
+            // allocate 300B mem
+            RingBuffer ringBuffer = RingBuffer.allocate(300);
+            while ((line = reader.readLine()) != null) {
+                ringBuffer.put((line + '\n').getBytes(StandardCharsets.UTF_8));
+            }
+
+            // assert actual log data > 600B, but only keep the last 300B
+            Assert.assertTrue(logBytes.length > 600 && ringBuffer.get().length == 300);
+
+            Assert.assertEquals(" [task-result-getter-0] scheduler.TaskSetManager:54 : Finished task 0.0 in stage 384.0 (TID 621) in 31 ms on kylin-hadoop-001 (executor 7) (1/1)\n" +
+                            "2022-11-09 18:25:48,689 INFO  [task-result-getter-0] cluster.YarnScheduler:54 : Removed TaskSet 384.0, whose tasks have all completed, from pool vip_tasks\n",
+                    new String(ringBuffer.get(), StandardCharsets.UTF_8));
+        }
+    }
+}


### PR DESCRIPTION
…r oom.

## Proposed changes

long running job's log staying in mem, may cause job server oom.

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [x] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
