### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/build-engine/src/main/java/org/apache/kylin/engine/mr/common/AbstractHadoopJob.java
+++ b/build-engine/src/main/java/org/apache/kylin/engine/mr/common/AbstractHadoopJob.java
@@ -29,6 +29,7 @@ import static org.apache.kylin.engine.mr.common.JobRelatedMetaUtil.collectCubeMe
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -595,7 +596,7 @@ public abstract class AbstractHadoopJob extends Configured implements Tool {
 
     protected void dumpKylinPropsAndMetadata(String prj, Set<String> dumpList, KylinConfig kylinConfig,
             Configuration conf) throws IOException {
-        File tmp = File.createTempFile("kylin_job_meta", "");
+        File tmp = Files.createTempFile("kylin_job_meta", "").toFile();
         FileUtils.forceDelete(tmp); // we need a directory, so delete the file first
 
         File metaDir = new File(tmp, "meta");

--- a/build-engine/src/main/java/org/apache/kylin/engine/mr/common/CubeStatsReader.java
+++ b/build-engine/src/main/java/org/apache/kylin/engine/mr/common/CubeStatsReader.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
@@ -156,7 +157,7 @@ public class CubeStatsReader {
     }
 
     private File writeTmpSeqFile(InputStream inputStream) throws IOException {
-        File tempFile = File.createTempFile("kylin_stats_tmp", ".seq");
+        File tempFile = Files.createTempFile("kylin_stats_tmp", ".seq").toFile();
         FileOutputStream out = null;
         try {
             out = new FileOutputStream(tempFile);

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/AutoDeleteDirectory.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/AutoDeleteDirectory.java
@@ -21,6 +21,7 @@ package org.apache.kylin.common.persistence;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class AutoDeleteDirectory implements Closeable {
 
@@ -31,7 +32,7 @@ public class AutoDeleteDirectory implements Closeable {
     }
     public AutoDeleteDirectory(String prefix, String suffix) {
         try {
-            tempFile = File.createTempFile(prefix, suffix);
+            tempFile = Files.createTempFile(prefix, suffix).toFile();
             org.apache.commons.io.FileUtils.forceDelete(tempFile); // we need a directory, so delete the file first
             tempFile.mkdirs();
         } catch (IOException e) {

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/FileResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/FileResourceStore.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
@@ -130,7 +131,7 @@ public class FileResourceStore extends ResourceStore {
         if (--failPutResourceCountDown == 0)
             throw new IOException("for test");
 
-        File tmp = File.createTempFile("kylin-fileresource-", ".tmp");
+        File tmp = Files.createTempFile("kylin-fileresource-", ".tmp").toFile();
         try {
 
             try (FileOutputStream out = new FileOutputStream(tmp); DataOutputStream dout = new DataOutputStream(out)) {

--- a/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceStore.java
+++ b/core-common/src/main/java/org/apache/kylin/common/persistence/ResourceStore.java
@@ -24,6 +24,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -787,7 +788,7 @@ abstract public class ResourceStore {
             boolean loadContent, Visitor visitor) throws IOException;
 
     public static String dumpResources(KylinConfig kylinConfig, Collection<String> dumpList) throws IOException {
-        File tmp = File.createTempFile("kylin_job_meta", "");
+        File tmp = Files.createTempFile("kylin_job_meta", "").toFile();
         FileUtils.forceDelete(tmp); // we need a directory, so delete the file first
 
         File metaDir = new File(tmp, "meta");

--- a/core-common/src/test/java/org/apache/kylin/common/util/SSHClientTest.java
+++ b/core-common/src/test/java/org/apache/kylin/common/util/SSHClientTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.kylin.common.KylinConfig;
@@ -81,7 +82,7 @@ public class SSHClientTest extends LocalFileMetadataTestCase {
             return;
 
         SSHClient ssh = new SSHClient(this.hostname, this.port, this.username, this.password);
-        File tmpFile = File.createTempFile("test_scp", "", new File("/tmp"));
+        File tmpFile = Files.createTempFile(new File("/tmp").toPath(), "test_scp", "").toFile();
         tmpFile.deleteOnExit();
         FileUtils.write(tmpFile, "test_scp", Charset.defaultCharset());
         ssh.scpFileToRemote(tmpFile.getAbsolutePath(), "/tmp");

--- a/core-cube/src/main/java/org/apache/kylin/gridtable/GTAggregateScanner.java
+++ b/core-cube/src/main/java/org/apache/kylin/gridtable/GTAggregateScanner.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -666,7 +667,7 @@ public class GTAggregateScanner implements IGTScanner, IGTBypassChecker {
             DataInputStream dis;
 
             public Dump(SortedMap<byte[], MeasureAggregator[]> buffMap, long estMemSize) throws IOException {
-                this.dumpedFile = File.createTempFile("KYLIN_SPILL_", ".tmp");
+                this.dumpedFile = Files.createTempFile("KYLIN_SPILL_", ".tmp").toFile();
                 this.buffMap = buffMap;
                 this.estMemSize = estMemSize;
             }

--- a/core-metadata/src/test/java/org/apache/kylin/measure/topn/TopNCounterTest.java
+++ b/core-metadata/src/test/java/org/apache/kylin/measure/topn/TopNCounterTest.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -76,7 +77,7 @@ public class TopNCounterTest {
         ZipfDistribution zipf = new ZipfDistribution(KEY_SPACE, 0.5);
         int keyIndex;
 
-        File tempFile = File.createTempFile("ZipfDistribution", ".txt");
+        File tempFile = Files.createTempFile("ZipfDistribution", ".txt").toFile();
 
         if (tempFile.exists())
             FileUtils.forceDelete(tempFile);

--- a/core-metadata/src/test/java/org/apache/kylin/source/H2Database.java
+++ b/core-metadata/src/test/java/org/apache/kylin/source/H2Database.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -93,7 +94,7 @@ public class H2Database {
         File tempFile = null;
 
         try {
-            tempFile = File.createTempFile("tmp_h2", ".csv");
+            tempFile = Files.createTempFile("tmp_h2", ".csv").toFile();
             FileOutputStream tempFileStream = new FileOutputStream(tempFile);
             String path = path(tableDesc);
             InputStream csvStream = metaMgr.getStore().getResource(path).content();

--- a/kylin-spark-project/kylin-spark-engine/src/main/java/org/apache/kylin/engine/spark/job/NSparkMergeStatisticsStep.java
+++ b/kylin-spark-project/kylin-spark-engine/src/main/java/org/apache/kylin/engine/spark/job/NSparkMergeStatisticsStep.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
@@ -94,7 +95,7 @@ public class NSparkMergeStatisticsStep extends NSparkExecutable {
                 File tempFile = null;
                 FileOutputStream tempFileStream = null;
                 try {
-                    tempFile = File.createTempFile(segmentId, ".seq");
+                    tempFile = Files.createTempFile(segmentId, ".seq").toFile();
                     tempFileStream = new FileOutputStream(tempFile);
                     org.apache.commons.io.IOUtils.copy(is, tempFileStream);
                 } finally {

--- a/kylin-spark-project/kylin-spark-engine/src/test/java/org/apache/kylin/engine/spark/NSparkBasicTest.java
+++ b/kylin-spark-project/kylin-spark-engine/src/test/java/org/apache/kylin/engine/spark/NSparkBasicTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.List;
 
 @Ignore("convenient trial tool for dev")
@@ -39,7 +40,7 @@ public class NSparkBasicTest extends LocalWithSparkSessionTest {
     @Test
     public void testToRdd() throws IOException {
         final String dataJson = "0,1,2,1000\n0,1,2,1\n3,4,5,2";
-        File dataFile = File.createTempFile("tmp", ".csv");
+        File dataFile = Files.createTempFile("tmp", ".csv").toFile();
         dataFile.deleteOnExit();
         FileUtils.writeStringToFile(dataFile, dataJson, Charset.defaultCharset());
 

--- a/query/src/main/java/org/apache/kylin/query/schema/OLAPSchemaFactory.java
+++ b/query/src/main/java/org/apache/kylin/query/schema/OLAPSchemaFactory.java
@@ -20,6 +20,7 @@ package org.apache.kylin.query.schema;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
@@ -119,7 +120,7 @@ public class OLAPSchemaFactory implements SchemaFactory {
             String jsonContent = out.toString();
             File file = cachedJsons.get(jsonContent);
             if (file == null) {
-                file = File.createTempFile("olap_model_", ".json");
+                file = Files.createTempFile("olap_model_", ".json").toFile();
                 file.deleteOnExit();
                 FileUtils.writeStringToFile(file, jsonContent);
 

--- a/tool/src/main/java/org/apache/kylin/tool/extractor/AbstractInfoExtractor.java
+++ b/tool/src/main/java/org/apache/kylin/tool/extractor/AbstractInfoExtractor.java
@@ -22,6 +22,7 @@ package org.apache.kylin.tool.extractor;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -122,7 +123,7 @@ public abstract class AbstractInfoExtractor extends AbstractApplication {
 
         // compress to zip package
         if (shouldCompress) {
-            File tempZipFile = File.createTempFile(packageType + "_", ".zip");
+            File tempZipFile = Files.createTempFile(packageType + "_", ".zip").toFile();
             File tempZipDir = new File(exportDest + packageName + "/");
             FileUtils.forceMkdir(tempZipDir);
             for (File file : exportDir.listFiles()) {

--- a/tool/src/test/java/org/apache/kylin/tool/KylinConfigCLITest.java
+++ b/tool/src/test/java/org/apache/kylin/tool/KylinConfigCLITest.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.kylin.common.util.LocalFileMetadataTestCase;
@@ -36,7 +37,7 @@ public class KylinConfigCLITest extends LocalFileMetadataTestCase {
     @Test
     public void testGetProperty() throws IOException {
         PrintStream o = System.out;
-        File f = File.createTempFile("cfg", ".tmp");
+        File f = Files.createTempFile("cfg", ".tmp").toFile();
         PrintStream tmpOut = new PrintStream(new FileOutputStream(f), false, "UTF-8");
         System.setOut(tmpOut);
         KylinConfigCLI.main(new String[] { "kylin.storage.url" });
@@ -51,7 +52,7 @@ public class KylinConfigCLITest extends LocalFileMetadataTestCase {
     @Test
     public void testGetPrefix() throws IOException {
         PrintStream o = System.out;
-        File f = File.createTempFile("cfg", ".tmp");
+        File f = Files.createTempFile("cfg", ".tmp").toFile();
         PrintStream tmpOut = new PrintStream(new FileOutputStream(f), false, "UTF-8");
         System.setOut(tmpOut);
         KylinConfigCLI.main(new String[] { "kylin.cube.engine." });


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
