### PR TITLE
KYLIN-5359 'replace' function expression convert error

### DIFF
--- a/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/kylin/query/runtime/ExpressionConverter.scala
+++ b/kylin-spark-project/kylin-spark-engine/src/main/scala/org/apache/kylin/query/runtime/ExpressionConverter.scala
@@ -173,8 +173,8 @@ object ExpressionConverter {
           case "character_length" => length(k_lit(children.head))
           case "replace" =>
             regexp_replace(k_lit(children.head),
-              children.apply(1).asInstanceOf[String],
-              children.apply(2).asInstanceOf[String])
+              k_lit(children.apply(1)),
+              k_lit(children.apply(2)))
           case "substring" | "substr" =>
             if (children.length == 3) { //substr(str1,startPos,length)
               k_lit(children.head)

--- a/kylin-spark-project/kylin-spark-query/src/main/scala/org/apache/kylin/query/runtime/ExpressionConverter.scala
+++ b/kylin-spark-project/kylin-spark-query/src/main/scala/org/apache/kylin/query/runtime/ExpressionConverter.scala
@@ -173,10 +173,10 @@ object ExpressionConverter {
           case "upper" => upper(k_lit(children.head))
           case "char_length" => length(k_lit(children.head))
           case "character_length" => length(k_lit(children.head))
-          case "replace " =>
+          case "replace" =>
             regexp_replace(k_lit(children.head),
-              children.apply(1).asInstanceOf[String],
-              children.apply(2).asInstanceOf[String])
+              k_lit(children.apply(1)),
+              k_lit(children.apply(2)))
           case "substring" | "substr" =>
             if (children.length == 3) { //substr(str1,startPos,length)
               k_lit(children.head)


### PR DESCRIPTION
## Proposed changes

statement "select name, replace(name, substring(name, 1, 1), '--') as new_name from LZ_TEST_YUFA " query failed,
errorMsg：java.lang.ClassCastException: org.apache.spark.sql.Column cannot be cast to java.lang.String while executing SQL: "select * from (select name, replace(name, substring(name, 1, 1), '--') as new_name from LZ_TEST_YUFA) limit 50000

Reason: In the ExpressionConverter, the substring returns a column object, while in the replace conversion, the function parameter is forced to be converted to a string.

![image](https://user-images.githubusercontent.com/49258176/206962003-70f078a0-592d-4769-b23a-8719c03d05b8.png)

![693fc61514e2819f2b042dad12da8d1](https://user-images.githubusercontent.com/49258176/206962216-6529e268-4bca-4d86-86d1-53068bcce0da.png)


## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [x] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
