### PR TITLE
 KYLIN-5381 Avoid timeout when cleaning query history by limiting the number of data deleted each time

### DIFF
--- a/src/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
+++ b/src/core-common/src/main/java/org/apache/kylin/common/KylinConfigBase.java
@@ -2801,6 +2801,10 @@ public abstract class KylinConfigBase implements Serializable {
         return Integer.parseInt(getOptional("kylin.query.queryhistory.project-max-size", "1000000"));
     }
 
+    public int getQueryHistorySingleDeletionSize() {
+        return Integer.parseInt(getOptional("kylin.query.queryhistory.single-deletion-size", "2000"));
+    }
+
     public long getQueryHistorySurvivalThreshold() {
         return TimeUtil.timeStringAs(getOptional("kylin.query.queryhistory.survival-time-threshold", "30d"),
                 TimeUnit.MILLISECONDS);

--- a/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/QueryHistoryDAO.java
+++ b/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/QueryHistoryDAO.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.metadata.query;
 
 import java.util.List;
+import java.util.Map;
 
 public interface QueryHistoryDAO {
 
@@ -44,9 +45,9 @@ public interface QueryHistoryDAO {
 
     void deleteQueryHistoriesIfMaxSizeReached();
 
-    void deleteQueryHistoriesIfProjectMaxSizeReached(String project);
-
     void deleteQueryHistoriesIfRetainTimeReached();
+
+    void deleteOldestQueryHistoriesByProject(String project, int deleteCount);
 
     long getQueryHistoriesSize(QueryHistoryRequest request, String project);
 
@@ -59,4 +60,7 @@ public interface QueryHistoryDAO {
     String getRealizationMetricMeasurement();
 
     List<QueryDailyStatistic> getQueryDailyStatistic(long startTime, long endTime);
+
+    Map<String, Long> getQueryCountByProject();
+
 }

--- a/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/QueryHistoryMapper.java
+++ b/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/QueryHistoryMapper.java
@@ -70,6 +70,12 @@ public interface QueryHistoryMapper {
     List<QueryHistory> selectMany(SelectStatementProvider selectStatement);
 
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
+    @Results(id = "QueryHistoryProjectInfoResult", value = {
+            @Result(column = "project_name", property = "projectName", jdbcType = JdbcType.VARCHAR),
+            @Result(column = "count", property = "count", jdbcType = JdbcType.BIGINT) })
+    List<QueryHistoryProjectInfo> selectByProject(SelectStatementProvider selectStatement);
+
+    @SelectProvider(type = SqlProviderAdapter.class, method = "select")
     @ResultMap("QueryHistoryResult")
     QueryHistory selectOne(SelectStatementProvider selectStatement);
 

--- a/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/QueryHistoryProjectInfo.java
+++ b/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/QueryHistoryProjectInfo.java
@@ -1,0 +1,20 @@
+package org.apache.kylin.metadata.query;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Setter
+@Slf4j
+public class QueryHistoryProjectInfo {
+
+    public static final String PROJECT_NAME = "project_name";
+
+    @JsonProperty(PROJECT_NAME)
+    private String projectName;
+
+    private long count;
+
+}

--- a/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/RDBMSQueryHistoryDAO.java
+++ b/src/core-metadata/src/main/java/org/apache/kylin/metadata/query/RDBMSQueryHistoryDAO.java
@@ -23,18 +23,19 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.kylin.common.KylinConfig;
 import org.apache.kylin.common.Singletons;
 import org.apache.kylin.common.StorageURL;
+import org.apache.kylin.common.persistence.transaction.UnitOfWork;
 import org.apache.kylin.common.util.Pair;
 import org.apache.kylin.common.util.TimeUtil;
-import org.apache.kylin.common.persistence.transaction.UnitOfWork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,8 +46,8 @@ public class RDBMSQueryHistoryDAO implements QueryHistoryDAO {
     private static final Logger logger = LoggerFactory.getLogger(RDBMSQueryHistoryDAO.class);
     @Setter
     private String queryMetricMeasurement;
-    private String realizationMetricMeasurement;
-    private JdbcQueryHistoryStore jdbcQueryHisStore;
+    private final String realizationMetricMeasurement;
+    private final JdbcQueryHistoryStore jdbcQueryHisStore;
 
     public static final String WEEK = "week";
     public static final String DAY = "day";
@@ -104,34 +105,43 @@ public class RDBMSQueryHistoryDAO implements QueryHistoryDAO {
         jdbcQueryHisStore.deleteQueryHistoryRealization(project);
     }
 
-    public void deleteQueryHistoriesIfMaxSizeReached() {
-        QueryHistory queryHistory = jdbcQueryHisStore
-                .queryOldestQueryHistory(KylinConfig.getInstanceFromEnv().getQueryHistoryMaxSize());
-        if (Objects.nonNull(queryHistory)) {
-            long time = queryHistory.getQueryTime();
-            jdbcQueryHisStore.deleteQueryHistory(time);
-            jdbcQueryHisStore.deleteQueryHistoryRealization(time);
-        }
-    }
-
     public QueryHistory getByQueryId(String queryId) {
         return jdbcQueryHisStore.queryByQueryId(queryId);
     }
 
-    public void deleteQueryHistoriesIfProjectMaxSizeReached(String project) {
-        QueryHistory queryHistory = jdbcQueryHisStore
-                .queryOldestQueryHistory(KylinConfig.getInstanceFromEnv().getQueryHistoryProjectMaxSize(), project);
-        if (Objects.nonNull(queryHistory)) {
-            long time = queryHistory.getQueryTime();
-            jdbcQueryHisStore.deleteQueryHistory(time, project);
-            jdbcQueryHisStore.deleteQueryHistoryRealization(time, project);
+    public void deleteQueryHistoriesIfMaxSizeReached() {
+        long maxSize = KylinConfig.getInstanceFromEnv().getQueryHistoryMaxSize();
+        long totalCount = jdbcQueryHisStore.getCountOnQueryHistory();
+        if (totalCount > maxSize) {
+            deleteQueryHistoryAndRealization((int) (totalCount - maxSize));
         }
     }
 
     public void deleteQueryHistoriesIfRetainTimeReached() {
-        long retainTime = getRetainTime();
-        jdbcQueryHisStore.deleteQueryHistory(retainTime);
-        jdbcQueryHisStore.deleteQueryHistoryRealization(retainTime);
+        long rangeOutCount = jdbcQueryHisStore.getCountOnQueryHistory(getRetainTime());
+        if (rangeOutCount > 0) {
+            deleteQueryHistoryAndRealization((int) rangeOutCount);
+        }
+    }
+
+    public void deleteQueryHistoryAndRealization(int deleteCount) {
+        int singleLimit = KylinConfig.getInstanceFromEnv().getQueryHistorySingleDeletionSize();
+        largeSplitToSmallTask(deleteCount, singleLimit, currentCount -> {
+            QueryHistory queryHistory = jdbcQueryHisStore.getOldestQueryHistory(currentCount);
+            int deletedRows = jdbcQueryHisStore.deleteQueryHistory(queryHistory.getId());
+            jdbcQueryHisStore.deleteQueryHistoryRealization(queryHistory.getQueryTime());
+            return deletedRows;
+        }, "Cleanup all query history");
+    }
+
+    public void deleteOldestQueryHistoriesByProject(String project, int deleteCount) {
+        int singleLimit = KylinConfig.getInstanceFromEnv().getQueryHistorySingleDeletionSize();
+        largeSplitToSmallTask(deleteCount, singleLimit, currentCount -> {
+            QueryHistory queryHistory = jdbcQueryHisStore.getOldestQueryHistory(project, currentCount);
+            int deletedRows = jdbcQueryHisStore.deleteQueryHistory(project, queryHistory.getId());
+            jdbcQueryHisStore.deleteQueryHistoryRealization(project, queryHistory.getQueryTime());
+            return deletedRows;
+        }, "Cleanup project<" + project + "> query history");
     }
 
     public void batchUpdateQueryHistoriesInfo(List<Pair<Long, QueryHistoryInfo>> idToQHInfoList) {
@@ -215,6 +225,11 @@ public class RDBMSQueryHistoryDAO implements QueryHistoryDAO {
         return jdbcQueryHisStore.queryAvgDurationByTime(startTime, endTime, timeDimension, project);
     }
 
+    @Override
+    public Map<String, Long> getQueryCountByProject() {
+        return jdbcQueryHisStore.getCountGroupByProject();
+    }
+
     public static void fillZeroForQueryStatistics(List<QueryStatistics> queryStatistics, long startTime, long endTime,
             String dimension) {
         if (!dimension.equalsIgnoreCase(DAY) && !dimension.equalsIgnoreCase(WEEK)) {
@@ -245,4 +260,19 @@ public class RDBMSQueryHistoryDAO implements QueryHistoryDAO {
             }
         }
     }
+
+    public static void largeSplitToSmallTask(int totalCount, int singleSize, IntFunction<Integer> function,
+            String description) {
+        int retainCount = totalCount;
+        while (retainCount > 0) {
+            int currentCount = Math.min(retainCount, singleSize);
+            int actualCount = function.apply(currentCount);
+            if (currentCount != actualCount && logger.isWarnEnabled()) {
+                logger.warn("The task {} was not performed as expected, expect:{}, actual:{}", description,
+                        currentCount, actualCount);
+            }
+            retainCount -= currentCount;
+        }
+    }
+
 }


### PR DESCRIPTION
 KYLIN-5381 Avoid timeout when cleaning query history by limiting the number of data deleted each time

Co-authored-by: hui.wang <hui.wang@kyligence.io>

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [ ] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [ ] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
