### PR TITLE
KYLIN-5391 Kylin metadata tool for read specific file.

### DIFF
--- a/build/bin/metastore.sh
+++ b/build/bin/metastore.sh
@@ -26,6 +26,8 @@ fi
 
 function help {
     echo "usage: metastore.sh backup METADATA_BACKUP_PATH(the default path is KYLIN_HOME/meta_backups/)"
+    echo "       metastore.sh fetch TARGET_FILE_PATH METADATA_FETCH_PATH(the default path is KYLIN_HOME/meta_fetch/)"
+    echo "       metastore.sh list TARGET_FOLDER_PATH"
     echo "       metastore.sh restore METADATA_RESTORE_PATH [--after-truncate]"
     echo "       metastore.sh backup-project PROJECT_NAME METADATA_BACKUP_PATH(the default path is KYLIN_HOME/meta_backups/)"
     echo "       metastore.sh restore-project PROJECT_NAME METADATA_RESTORE_PATH [--after-truncate]"
@@ -42,6 +44,18 @@ function printBackupResult() {
     else
         echo -e "${YELLOW}Backup failed. Detailed Message is at \"logs/shell.stderr\".${RESTORE}"
     fi
+}
+
+function printFetchResult() {
+  error=$1
+  if [[ $error == 0 ]]; then
+      if [[ -z "$path" ]]; then
+          path="\${KYLIN_HOME}/meta_fetch"
+      fi
+      echo -e "${YELLOW} Fetch at local dist succeed.${RESTORE}"
+  else
+      echo -e "${YELLOW} Fetch failed.${RESTORE}"
+  fi
 }
 
 function printRestoreResult() {
@@ -134,6 +148,34 @@ then
     ${KYLIN_HOME}/bin/kylin.sh org.apache.kylin.tool.MetadataTool ${BACKUP_OPTS}
     printBackupResult $?
 
+elif [ "$1" == "fetch" ]
+then
+    FETCH_OPTS="-fetch"
+    if [ $# -eq 2 ]; then
+        _file=$2
+        FETCH_OPTS="${FETCH_OPTS} -target ${_file}"
+    elif [ $# -eq 3 ]; then
+        _file=$2
+        path=`cd $3 && pwd -P`
+        check_path_empty ${path}
+        FETCH_OPTS="${FETCH_OPTS} -target ${_file} -dir ${path}"
+    else
+        help
+    fi
+
+    ${KYLIN_HOME}/bin/kylin.sh org.apache.kylin.tool.MetadataTool ${FETCH_OPTS}
+    printFetchResult $?
+
+elif [ "$1" == "list" ]
+then
+    if [ $# -eq 2 ]; then
+        _folder=$2
+        LIST_OPTS="-list -target ${_folder}"
+    else
+        help
+    fi
+    ${KYLIN_HOME}/bin/kylin.sh org.apache.kylin.tool.MetadataTool ${LIST_OPTS}
+
 elif [ "$1" == "restore" ]
 then
     if [ $# -eq 2 ]; then
@@ -170,5 +212,4 @@ then
 else
     help
 fi
-
 

--- a/src/tool/src/test/java/org/apache/kylin/tool/MetadataToolTest.java
+++ b/src/tool/src/test/java/org/apache/kylin/tool/MetadataToolTest.java
@@ -125,6 +125,32 @@ public class MetadataToolTest extends NLocalFileMetadataTestCase {
     }
 
     @Test
+    public void testFetchTargetFile() throws IOException {
+        val junitFolder = temporaryFolder.getRoot();
+        val tool = new MetadataTool(getTestConfig());
+        tool.execute(new String[] {
+                "-fetch", "-target", "default/table/DEFAULT.STREAMING_TABLE.json", "-dir", junitFolder.getAbsolutePath(), "-folder", "target_fetch"
+        });
+
+        Assertions.assertThat(junitFolder.listFiles()).hasSize(1);
+        val archiveFolder = junitFolder.listFiles()[0];
+        Assertions.assertThat(archiveFolder).exists();
+
+        Assertions.assertThat(archiveFolder.list()).isNotEmpty().containsOnly("default", "UUID");
+
+        val projectFolder = findFile(archiveFolder.listFiles(), f -> f.getName().equals("default"));
+        assertProjectFolder(projectFolder, archiveFolder);
+    }
+
+    @Test
+    public void testListFile() {
+        val tool = new MetadataTool(getTestConfig());
+        tool.execute(new String[] {
+                "-list", "-target", "default"
+        });
+    }
+
+    @Test
     public void testBackupProject() throws IOException {
         val junitFolder = temporaryFolder.getRoot();
         val tool = new MetadataTool(getTestConfig());

--- a/src/tool/src/test/java/org/apache/kylin/tool/MetadataToolTest.java
+++ b/src/tool/src/test/java/org/apache/kylin/tool/MetadataToolTest.java
@@ -128,18 +128,24 @@ public class MetadataToolTest extends NLocalFileMetadataTestCase {
     public void testFetchTargetFile() throws IOException {
         val junitFolder = temporaryFolder.getRoot();
         val tool = new MetadataTool(getTestConfig());
+        // test case for fetching a specific file
         tool.execute(new String[] {
                 "-fetch", "-target", "default/table/DEFAULT.STREAMING_TABLE.json", "-dir", junitFolder.getAbsolutePath(), "-folder", "target_fetch"
         });
+        //test case for fetching a folder
+        tool.execute(new String[] {
+                "-fetch", "-target", "_global", "-dir", junitFolder.getAbsolutePath(), "-folder", "target_fetch_global"
+        });
 
-        Assertions.assertThat(junitFolder.listFiles()).hasSize(1);
-        val archiveFolder = junitFolder.listFiles()[0];
+        Assertions.assertThat(junitFolder.listFiles()).hasSize(2);
+        val archiveFolder = junitFolder.listFiles()[1];
+        val globleFolder = junitFolder.listFiles()[0];
         Assertions.assertThat(archiveFolder).exists();
 
         Assertions.assertThat(archiveFolder.list()).isNotEmpty().containsOnly("default", "UUID");
 
         val projectFolder = findFile(archiveFolder.listFiles(), f -> f.getName().equals("default"));
-        assertProjectFolder(projectFolder, archiveFolder);
+        assertProjectFolder(projectFolder, globleFolder);
     }
 
     @Test


### PR DESCRIPTION
Currently, kylin metadata tool supports backup metadata files at project level or model level. We can add an api for listing files under a specific folder path and fetching the specific metadata at file level.

## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [ ] Branch **kylin4** for v4.x
- [x] Branch **kylin5** for v5.x

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN-5391), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-5391 Metadata tool for fetch and list at file level"
- [x] Compiling and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
