### PR TITLE
KYLIN-5539 need close FSDataInputStream

### DIFF
--- a/kylin-spark-project/kylin-spark-engine/src/main/java/org/apache/kylin/engine/spark/utils/UpdateMetadataUtil.java
+++ b/kylin-spark-project/kylin-spark-engine/src/main/java/org/apache/kylin/engine/spark/utils/UpdateMetadataUtil.java
@@ -91,8 +91,9 @@ public class UpdateMetadataUtil {
         Path statisticsFile = new Path(statisticsDir, BatchConstants.CFG_STATISTICS_CUBOID_ESTIMATION_FILENAME);
         FileSystem fs = HadoopUtil.getWorkingFileSystem();
         if (fs.exists(statisticsFile)) {
-            FSDataInputStream is = fs.open(statisticsFile);
-            ResourceStore.getStore(config).putBigResource(resKey, is, System.currentTimeMillis());
+            try (FSDataInputStream is = fs.open(statisticsFile)) {
+                ResourceStore.getStore(config).putBigResource(resKey, is, System.currentTimeMillis());
+            }
         }
 
         CubeUpdate update = new CubeUpdate(currentInstanceCopy);


### PR DESCRIPTION
## Proposed changes

1.初始发现：线上告警某节点存在大量的CLOSE_WAIT，通过 netstat -anp 发现来自于Kylin4 JobServer 进程，CLOSE_WAIT数达到9000多。并且 CLOSE_WAIT 来自的外部地址端口都是 50010，而该端口是 Hadoop DataNode 数据传输使用，故此怀疑是 JobServer在每次作业构建时 fileSystem.open() 一个流后没有进行close。
2.模拟复现：在研测环境提交cube构建任务，并观察 CLOSE_WAIT 数及增长情况，发现每次cube构建结束后，CLOSE_WAIT 数增加1，至此可以确定是JobServer代码中未关闭流导致。
3.定位代码：深入kylin4 构建代码进行debug，最终定位到 org.apache.kylin.engine.spark.utils.UpdateMetadataUtil#syncLocalMetadataToRemote 94行 （Apache Kylin main分支）

String resKey = toUpdateSeg.getStatisticsResourcePath();
String statisticsDir = config.getJobTmpDir(currentInstanceCopy.getProject()) + "/"
+ nsparkExecutable.getParam(MetadataConstants.P_JOB_ID) + "/" + ResourceStore.CUBE_STATISTICS_ROOT + "/"
+ cubeId + "/" + segmentId + "/";
Path statisticsFile = new Path(statisticsDir, BatchConstants.CFG_STATISTICS_CUBOID_ESTIMATION_FILENAME);
FileSystem fs = HadoopUtil.getWorkingFileSystem();
if (fs.exists(statisticsFile)) {
FSDataInputStream is = fs.open(statisticsFile); //未关闭流
ResourceStore.getStore(config).putBigResource(resKey, is, System.currentTimeMillis());
}

CubeUpdate update = new CubeUpdate(currentInstanceCopy);
update.setCuboids(distCube.getCuboids());
List<CubeSegment> toRemoveSegs = Lists.newArrayList();
4. 研测验证：
Path statisticsFile = new Path(statisticsDir, BatchConstants.CFG_STATISTICS_CUBOID_ESTIMATION_FILENAME);
FileSystem fs = HadoopUtil.getWorkingFileSystem();
if (fs.exists(statisticsFile)) {
try (FSDataInputStream is = fs.open(statisticsFile)) { // 关闭流
ResourceStore.getStore(config).putBigResource(resKey, is, System.currentTimeMillis());
}
}
修改代码后，在研测环境进行多轮cube构建测试，CLOSE_WAIT 均无增加，验证解决。

![image](https://user-images.githubusercontent.com/49258176/235130020-4929b952-1c5b-4a86-861c-08b38ca284ce.png)


## Branch to commit
- [ ] Branch **kylin3** for v2.x to v3.x
- [x] Branch **kylin4** for v4.x
- [ ] Branch **kylin5** for v5.x

## Types of changes

What types of changes does your code introduce to Kylin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have created an issue on [Kylin's jira](https://issues.apache.org/jira/browse/KYLIN), and have described the bug/feature there in detail
- [x] Commit messages in my PR start with the related jira ID, like "KYLIN-0000 Make Kylin project open-source"
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at user@kylin.apache.org or dev@kylin.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
