### PR TITLE
KYLIN-5748 Skip build flat table for index build job if all new created indexes can be built from existed parent index

### DIFF
--- a/src/core-metadata/src/main/java/org/apache/kylin/metadata/cube/model/NBatchConstants.java
+++ b/src/core-metadata/src/main/java/org/apache/kylin/metadata/cube/model/NBatchConstants.java
@@ -42,6 +42,7 @@ public interface NBatchConstants {
     String P_PARTITION_IDS = "partitionIds";
     String P_BUCKETS = "buckets";
 
+    String P_IS_INDEX_BUILD = "isIndexBuild";
     String P_INCREMENTAL_BUILD = "incrementalBuild";
     String P_SELECTED_PARTITION_COL = "selectedPartitionCol";
     String P_SELECTED_PARTITION_VALUE = "selectedPartition";

--- a/src/spark-project/engine-spark/src/main/java/org/apache/kylin/engine/spark/job/NSparkCubingJob.java
+++ b/src/spark-project/engine-spark/src/main/java/org/apache/kylin/engine/spark/job/NSparkCubingJob.java
@@ -183,6 +183,9 @@ public class NSparkCubingJob extends DefaultExecutableOnModel {
         job.setParam(NBatchConstants.P_SEGMENT_IDS, String.join(",", job.getTargetSegments()));
         job.setParam(NBatchConstants.P_DATA_RANGE_START, String.valueOf(startTime));
         job.setParam(NBatchConstants.P_DATA_RANGE_END, String.valueOf(endTime));
+        if (isIndexBuildJob(jobType)) {
+            job.setParam(NBatchConstants.P_IS_INDEX_BUILD, String.valueOf(true));
+        }
         if (CollectionUtils.isNotEmpty(ignoredSnapshotTables)) {
             job.setParam(NBatchConstants.P_IGNORED_SNAPSHOT_TABLES, String.join(",", ignoredSnapshotTables));
         }
@@ -321,6 +324,10 @@ public class NSparkCubingJob extends DefaultExecutableOnModel {
 
     public SparkCleanupTransactionalTableStep getCleanIntermediateTableStep() {
         return getTask(SparkCleanupTransactionalTableStep.class);
+    }
+
+    private static boolean isIndexBuildJob(JobTypeEnum jobType) {
+        return JobTypeEnum.INDEX_BUILD.equals(jobType);
     }
 
     @Override

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/SegmentBuildJob.java
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/SegmentBuildJob.java
@@ -33,6 +33,7 @@ import org.apache.kylin.engine.spark.job.stage.StageExec;
 import org.apache.kylin.guava30.shaded.common.base.Throwables;
 import org.apache.kylin.guava30.shaded.common.collect.Lists;
 import org.apache.kylin.job.execution.ExecutableState;
+import org.apache.kylin.metadata.cube.cuboid.AdaptiveSpanningTree;
 import org.apache.kylin.metadata.cube.model.NBatchConstants;
 import org.apache.kylin.metadata.cube.model.NDataSegment;
 import org.apache.kylin.metadata.cube.model.NDataflow;
@@ -62,6 +63,7 @@ import static org.apache.kylin.engine.spark.job.StageType.WAITE_FOR_RESOURCE;
 public class SegmentBuildJob extends SegmentJob {
 
     private boolean usePlanner = false;
+    private boolean isIndexBuild = false;
 
     public static void main(String[] args) {
         SegmentBuildJob segmentBuildJob = new SegmentBuildJob();
@@ -74,6 +76,10 @@ public class SegmentBuildJob extends SegmentJob {
         String enablePlanner = getParam(NBatchConstants.P_JOB_ENABLE_PLANNER);
         if (enablePlanner != null && Boolean.valueOf(enablePlanner)) {
             usePlanner = true;
+        }
+        String isIndexBuildJob = getParam(NBatchConstants.P_IS_INDEX_BUILD);
+        if (isIndexBuildJob != null && Boolean.valueOf(isIndexBuildJob)) {
+            isIndexBuild = true;
         }
     }
 
@@ -145,6 +151,21 @@ public class SegmentBuildJob extends SegmentJob {
 
                 val buildParam = new BuildParam();
                 MATERIALIZED_FACT_TABLE.createStage(this, seg, buildParam, exec);
+                if (isIndexBuild) {
+                    if (Objects.isNull(buildParam.getBuildFlatTable())) {
+                        val spanTree = new AdaptiveSpanningTree(config,
+                                new AdaptiveSpanningTree.AdaptiveTreeBuilder(seg, this.getReadOnlyLayouts()));
+                        buildParam.setSpanningTree(spanTree);
+                    }
+                    if (!buildParam.getSpanningTree().fromFlatTable()) {
+                        log.info("this is an index build job for segment " +
+                                seg.getId() +
+                                " and all new created indexes will be built from parent index, " +
+                                "will skip build dict and generate flat table");
+                        buildParam.setSkipBuildDict(true);
+                        buildParam.setSkipGenerateFlatTable(true);
+                    }
+                }
                 BUILD_DICT.createStage(this, seg, buildParam, exec);
                 GENERATE_FLAT_TABLE.createStage(this, seg, buildParam, exec);
                 // enable cost based planner according to the parameter

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/BuildParam.scala
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/BuildParam.scala
@@ -49,6 +49,7 @@ class BuildParam {
   private var cachedPartitionStats: Map[Long, Statistics] =
     immutable.Map.newBuilder[Long, Statistics].result()
 
+  private var skipBuildDict: Boolean = _
   private var skipGenerateFlatTable: Boolean = _
   private var skipMaterializedFactTableView: Boolean = _
 
@@ -71,6 +72,12 @@ class BuildParam {
 
   def setSkipMaterializedFactTableView(skipMaterializedFactTableView: Boolean): Unit = {
     this.skipMaterializedFactTableView = skipMaterializedFactTableView
+  }
+
+  def isSkipBuildDict: Boolean = skipBuildDict;
+
+  def setSkipBuildDict(skipBuildDict: Boolean): Unit = {
+    this.skipBuildDict = skipBuildDict
   }
 
   def isSkipGenerateFlatTable: Boolean = skipGenerateFlatTable

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/BuildParam.scala
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/BuildParam.scala
@@ -74,7 +74,7 @@ class BuildParam {
     this.skipMaterializedFactTableView = skipMaterializedFactTableView
   }
 
-  def isSkipBuildDict: Boolean = skipBuildDict;
+  def isSkipBuildDict: Boolean = skipBuildDict
 
   def setSkipBuildDict(skipBuildDict: Boolean): Unit = {
     this.skipBuildDict = skipBuildDict

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/build/BuildDict.scala
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/build/BuildDict.scala
@@ -32,5 +32,9 @@ class BuildDict(jobContext: SegmentJob, dataSegment: NDataSegment, buildParam: B
     buildParam.setDict(dict)
   }
 
+  if (buildParam.isSkipBuildDict) {
+    onStageSkipped()
+  }
+
   override def getStageName: String = "BuildDict"
 }

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/build/partition/PartitionBuildDict.scala
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/kylin/engine/spark/job/stage/build/partition/PartitionBuildDict.scala
@@ -29,7 +29,10 @@ class PartitionBuildDict(jobContext: SegmentJob, dataSegment: NDataSegment, buil
   override def execute(): Unit = {
     val dict: Dataset[Row] = buildDictIfNeed()
     buildParam.setDict(dict)
-  }
 
+    if (buildParam.isSkipBuildDict) {
+      onStageSkipped()
+    }
+  }
   override def getStageName: String = "PartitionBuildDict"
 }

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
@@ -99,7 +99,7 @@ class JobWorkSpace(eventLoop: KylinJobEventLoop, monitor: JobMonitor, worker: Jo
 
   def fail(jf: JobFailed): Unit = {
     try {
-      logError(s"Job failed eventually. Reason: ${jf.reason}", jf.throwable.getCause)
+      logError(s"Job failed eventually. Reason: ${jf.reason}", jf.throwable)
       KylinBuildEnv.get().buildJobInfos.recordJobRetryInfos(RetryInfo(new util.HashMap, jf.throwable))
       worker.getApplication.updateJobErrorInfo(jf)
       stop()

--- a/src/spark-project/engine-spark/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
+++ b/src/spark-project/engine-spark/src/main/scala/org/apache/spark/application/JobWorkSpace.scala
@@ -99,7 +99,7 @@ class JobWorkSpace(eventLoop: KylinJobEventLoop, monitor: JobMonitor, worker: Jo
 
   def fail(jf: JobFailed): Unit = {
     try {
-      logError(s"Job failed eventually. Reason: ${jf.reason}", jf.throwable)
+      logError(s"Job failed eventually. Reason: ${jf.reason}", jf.throwable.getCause)
       KylinBuildEnv.get().buildJobInfos.recordJobRetryInfos(RetryInfo(new util.HashMap, jf.throwable))
       worker.getApplication.updateJobErrorInfo(jf)
       stop()


### PR DESCRIPTION
For an index build job, if all the new added indexes can be built from their existed parent index. No index was built from new created flat table.
For this case, there won't be any data inconsistency across indexes. And there is no need to build a new flat table to serve the stage of index build by layer.
So I think we can skip stage BUILD DICT and stage GENERATE FLAT TABLE for an index build job in condition that all new added indexes can be built from their existed parent index