### PR TITLE
fix multi session password change

### DIFF
--- a/server-base/src/main/java/org/apache/kylin/rest/security/ManagedUser.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/security/ManagedUser.java
@@ -252,8 +252,7 @@ public class ManagedUser extends RootPersistentEntity implements UserDetails {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), username, password, authorities, disabled, defaultPassword, locked,
-                lockedTime, wrongTime);
+        return Objects.hash(uuid);
     }
 
     @Override

--- a/server-base/src/main/java/org/apache/kylin/rest/service/KylinUserService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/KylinUserService.java
@@ -192,6 +192,10 @@ public class KylinUserService implements UserService {
         return getManagedUsersByFuzzMatching(userName, isFuzzMatch, userList, null);
     }
 
+    public ManagedUser getUser(String userName) {
+        return getKylinUserManager().get(userName);
+    }
+
     @Override
     public List<ManagedUser> listUsers(String userName, String groupName, Boolean isFuzzMatch) throws IOException {
         List<ManagedUser> userList = getKylinUserManager().list();

--- a/server-base/src/main/java/org/apache/kylin/rest/service/UserService.java
+++ b/server-base/src/main/java/org/apache/kylin/rest/service/UserService.java
@@ -30,6 +30,8 @@ public interface UserService extends UserDetailsManager {
 
     List<ManagedUser> listUsers(String userName, Boolean isFuzzyMatch) throws IOException;
 
+    ManagedUser getUser(String userName);
+
     List<ManagedUser> listUsers(String userName, String groupName, Boolean isFuzzyMatch) throws IOException;
 
     List<String> listAdminUsers() throws IOException;

--- a/server/src/main/resources/kylinSecurity.xml
+++ b/server/src/main/resources/kylinSecurity.xml
@@ -30,6 +30,28 @@
     </scr:global-method-security>
 
 
+    <bean id="concurrencyFilter"
+                class="org.springframework.security.web.session.ConcurrentSessionFilter">
+        <constructor-arg name="sessionRegistry" ref="sessionRegistry" />
+        <constructor-arg name="sessionInformationExpiredStrategy" ref="redirectSessionInformationExpiredStrategy" />
+    </bean>
+    <bean id="redirectSessionInformationExpiredStrategy"
+                class="org.springframework.security.web.session.SimpleRedirectSessionInformationExpiredStrategy">
+        <constructor-arg name="invalidSessionUrl" value="/session-expired.htm" />
+    </bean>
+
+    <bean id="sessionRegistry" class="org.springframework.security.core.session.SessionRegistryImpl" />
+    <bean id="sas" class="org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy">
+        <constructor-arg>
+            <list>
+                <bean class="org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy">
+                </bean>
+                <bean class="org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy">
+                    <constructor-arg ref="sessionRegistry"/>
+                </bean>
+            </list>
+        </constructor-arg>
+    </bean>
     <!-- acl config -->
     <bean id="aclPermissionFactory" class="org.apache.kylin.rest.security.AclPermissionFactory"/>
 
@@ -259,9 +281,10 @@
             <scr:intercept-url pattern="/api/**" access="isAuthenticated()"/>
 
             <scr:form-login login-page="/login"/>
+            <scr:custom-filter position="CONCURRENT_SESSION_FILTER" ref="concurrencyFilter" />
             <scr:logout invalidate-session="true" delete-cookies="JSESSIONID" logout-url="/j_spring_security_logout"
                         logout-success-url="/."/>
-            <scr:session-management session-fixation-protection="newSession"/>
+            <scr:session-management session-authentication-strategy-ref="sas"/>
         </scr:http>
     </beans>
 
@@ -308,9 +331,10 @@
             <scr:intercept-url pattern="/api/**" access="isAuthenticated()"/>
 
             <scr:form-login login-page="/login"/>
+            <scr:custom-filter position="CONCURRENT_SESSION_FILTER" ref="concurrencyFilter" />
             <scr:logout invalidate-session="true" delete-cookies="JSESSIONID" logout-url="/j_spring_security_logout"
                         logout-success-url="/."/>
-            <scr:session-management session-fixation-protection="newSession"/>
+            <scr:session-management session-authentication-strategy-ref="sas"/>
         </scr:http>
 
         <!-- Secured non-api urls with SAML SSO -->
@@ -320,6 +344,8 @@
             <scr:intercept-url pattern="/**" access="IS_AUTHENTICATED_FULLY"/>
             <scr:custom-filter before="FIRST" ref="metadataGeneratorFilter"/>
             <scr:custom-filter after="BASIC_AUTH_FILTER" ref="samlFilter"/>
+            <scr:custom-filter position="CONCURRENT_SESSION_FILTER" ref="concurrencyFilter" />
+            <scr:session-management session-authentication-strategy-ref="sas"/>
         </scr:http>
 
 


### PR DESCRIPTION
Clear the authentication cache to prevent logging in with the old password after a password reset.
Expire the user's related session after their password reset.